### PR TITLE
Update Node version in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js  
         uses: actions/setup-node@v4  
         with:  
-          node-version: '10.9.2'  
+          node-version: '20'  
           cache: 'npm'  
       
       - name: Install dependencies  


### PR DESCRIPTION
## Summary
- use Node 20 for GitHub Pages deploy workflow

## Testing
- `npm ci` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_685e957c09648332836cf4900eb0a35d