### PR TITLE
Add mapbox alias in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,12 @@ export default defineConfig({
   // base: process.env.BASE_URL || '/',  
   base: '/golden_path/',
   // Add this for PWA  
-  publicDir: 'public',  
+  publicDir: 'public',
+  resolve: {
+    alias: {
+      'mapbox-gl': 'maplibre-gl'
+    }
+  },
   //base: './', // This helps with relative paths in the production build
   plugins: [  
     react(),  


### PR DESCRIPTION
## Summary
- map `mapbox-gl` imports to `maplibre-gl` in Vite

## Testing
- `npm run dev` *(fails: vite not installed)*
- `npm run lint` *(fails: missing eslint packages)*

------
https://chatgpt.com/codex/tasks/task_e_685f7f1035ec8332863379b57fb53d33