### PR TITLE
Set Vite base path based on environment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,12 @@
-import { defineConfig } from 'vite';  
-import react from '@vitejs/plugin-react';  
-import { VitePWA } from 'vite-plugin-pwa';  
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 
-export default defineConfig({  
-  // base: process.env.BASE_URL || '/',  
-  base: '/golden_path/',
+const isProd = process.env.NODE_ENV === 'production';
+
+export default defineConfig({
+  // base: process.env.BASE_URL || '/',
+  base: isProd ? '/golden_path/' : '/',
   // Add this for PWA  
   publicDir: 'public',  
   //base: './', // This helps with relative paths in the production build


### PR DESCRIPTION
## Summary
- set the Vite `base` option to `/golden_path/` only when building for production

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7f2798d48332853dbba3d56492ea