### PR TITLE
Fix data fetch paths for public JSON files

### DIFF
--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -34,7 +34,7 @@ const Location = () => {
 
   // Fetch routingData.json from public folder
   useEffect(() => {
-    fetch('./data/routing-data.json')
+    fetch('/data/routing-data.json')
       .then(res => res.json())
       .then(data => setRoutingData(data))
       .catch(err => console.error('Failed to load routing-data.json', err));
@@ -229,7 +229,7 @@ const Location = () => {
   useEffect(() => {
     const fetchLocationData = async () => {
       try {
-        const response = await axios.get('./data/locationData.json');
+        const response = await axios.get('/data/locationData.json');
         setLocationData(response.data);
         setComments(response.data.comments || []);
         setViews(response.data.views || 0);


### PR DESCRIPTION
## Summary
- load `routing-data.json` and `locationData.json` using absolute paths so the fetch succeeds regardless of route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685f823aa31c833290bcf6bd70b8451e