### PR TITLE
Fix Map component syntax

### DIFF
--- a/src/pages/RouteOverview.jsx
+++ b/src/pages/RouteOverview.jsx
@@ -134,7 +134,7 @@ const RouteOverview = () => {
       <div className="route-map-container">
         <Map
           mapLib={maplibregl}
-
+        >
           <Marker longitude={routeCoordinates[0][1]} latitude={routeCoordinates[0][0]} anchor="bottom">
             <div className="c-circle"></div>
           </Marker>


### PR DESCRIPTION
## Summary
- close `<Map>` tag properly in `RouteOverview.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685fa6e67ac883328ceec29c797931c1