### PR TITLE
Use OSM WMS tiles

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmWMSStyle from '../../services/osmWMSStyle';
 
 const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapClick, isSelectingLocation }) => {
   const [viewState, setViewState] = useState({
@@ -76,7 +77,7 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
   return (
     <Map
       mapLib={maplibregl}
-      mapStyle="https://demotiles.maplibre.org/style.json"
+      mapStyle={osmWMSStyle}
       style={{ width: '100%', height: '100%' }}
       viewState={viewState}
       onClick={handleClick}

--- a/src/components/map/MapView.jsx
+++ b/src/components/map/MapView.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import Map, { Marker, Popup, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import DeadReckoningControls from './DeadReckoningControls';
+import osmWMSStyle from '../../services/osmWMSStyle';
 
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './Map.css';
@@ -199,7 +200,7 @@ const MapView = ({
     <div className="map-fullscreen">
       <Map
         mapLib={maplibregl}
-        mapStyle="https://demotiles.maplibre.org/style.json"
+        mapStyle={osmWMSStyle}
         style={{ width: '100%', height: '100%' }}
         viewState={viewState}
         onMove={handleMove}

--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmWMSStyle from '../../services/osmWMSStyle';
 
 const RouteMap = ({ origin, destination, routeOptions }) => {
   const center = origin?.coordinates || [36.297, 59.606];
@@ -17,7 +18,7 @@ const RouteMap = ({ origin, destination, routeOptions }) => {
     <div id="route-map" className="route-map-container">
       <Map
         mapLib={maplibregl}
-        mapStyle="https://demotiles.maplibre.org/style.json"
+        mapStyle={osmWMSStyle}
         style={{ width: '100%', height: '100%' }}
         initialViewState={{
           latitude: center[0],

--- a/src/components/map/Routing.jsx
+++ b/src/components/map/Routing.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmWMSStyle from '../../services/osmWMSStyle';
 
 const Routing = ({ userLocation, routeSteps, currentStep }) => {
   const initial = routeSteps && routeSteps.length > 0 ? routeSteps[0].coordinates : [36.2880, 59.6157];
@@ -30,7 +31,7 @@ const Routing = ({ userLocation, routeSteps, currentStep }) => {
     <div ref={null} className="route-map">
       <Map
         mapLib={maplibregl}
-        mapStyle="https://demotiles.maplibre.org/style.json"
+        mapStyle={osmWMSStyle}
         style={{ width: '100%', height: '100%' }}
         viewState={viewState}
       >

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmWMSStyle from '../services/osmWMSStyle';
 import '../styles/FinalSearch.css';
 
 const FinalSearch = () => {
@@ -171,7 +172,7 @@ const FinalSearch = () => {
       <div className="mpr">
         <Map
           mapLib={maplibregl}
-          mapStyle="https://demotiles.maplibre.org/style.json"
+          mapStyle={osmWMSStyle}
           style={{ width: '100%', height: '100%' }}
 
         >

--- a/src/services/osmWMSStyle.js
+++ b/src/services/osmWMSStyle.js
@@ -1,0 +1,19 @@
+export default {
+  version: 8,
+  sources: {
+    'osm-wms': {
+      type: 'raster',
+      tiles: [
+        'https://ows.terrestris.de/osm/service?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=TRUE&LAYERS=OSM-WMS&SRS=EPSG:3857&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
+      ],
+      tileSize: 256
+    }
+  },
+  layers: [
+    {
+      id: 'osm-wms',
+      type: 'raster',
+      source: 'osm-wms'
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- add a new MapLibre style that pulls tiles from a free OSM WMS service
- use that style in all map components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685fa860abe88332b673c56c553564f8