### PR TITLE
Use OSM raster tiles instead of WMS

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmStyle from '../../services/osmStyle';
 
 const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapClick, isSelectingLocation }) => {
   const [viewState, setViewState] = useState({
@@ -76,7 +77,7 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
   return (
     <Map
       mapLib={maplibregl}
-      mapStyle="https://demotiles.maplibre.org/style.json"
+      mapStyle={osmStyle}
       style={{ width: '100%', height: '100%' }}
       viewState={viewState}
       onClick={handleClick}

--- a/src/components/map/MapView.jsx
+++ b/src/components/map/MapView.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import Map, { Marker, Popup, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import DeadReckoningControls from './DeadReckoningControls';
+import osmStyle from '../../services/osmStyle';
 
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './Map.css';
@@ -199,7 +200,7 @@ const MapView = ({
     <div className="map-fullscreen">
       <Map
         mapLib={maplibregl}
-        mapStyle="https://demotiles.maplibre.org/style.json"
+        mapStyle={osmStyle}
         style={{ width: '100%', height: '100%' }}
         viewState={viewState}
         onMove={handleMove}

--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmStyle from '../../services/osmStyle';
 
 const RouteMap = ({ origin, destination, routeOptions }) => {
   const center = origin?.coordinates || [36.297, 59.606];
@@ -17,7 +18,7 @@ const RouteMap = ({ origin, destination, routeOptions }) => {
     <div id="route-map" className="route-map-container">
       <Map
         mapLib={maplibregl}
-        mapStyle="https://demotiles.maplibre.org/style.json"
+        mapStyle={osmStyle}
         style={{ width: '100%', height: '100%' }}
         initialViewState={{
           latitude: center[0],

--- a/src/components/map/Routing.jsx
+++ b/src/components/map/Routing.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmStyle from '../../services/osmStyle';
 
 const Routing = ({ userLocation, routeSteps, currentStep }) => {
   const initial = routeSteps && routeSteps.length > 0 ? routeSteps[0].coordinates : [36.2880, 59.6157];
@@ -30,7 +31,7 @@ const Routing = ({ userLocation, routeSteps, currentStep }) => {
     <div ref={null} className="route-map">
       <Map
         mapLib={maplibregl}
-        mapStyle="https://demotiles.maplibre.org/style.json"
+        mapStyle={osmStyle}
         style={{ width: '100%', height: '100%' }}
         viewState={viewState}
       >

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
+import osmStyle from '../services/osmStyle';
 import '../styles/FinalSearch.css';
 
 const FinalSearch = () => {
@@ -171,7 +172,7 @@ const FinalSearch = () => {
       <div className="mpr">
         <Map
           mapLib={maplibregl}
-          mapStyle="https://demotiles.maplibre.org/style.json"
+          mapStyle={osmStyle}
           style={{ width: '100%', height: '100%' }}
 
         >

--- a/src/services/osmStyle.js
+++ b/src/services/osmStyle.js
@@ -1,0 +1,23 @@
+export default {
+  version: 8,
+  sources: {
+    'osm-tiles': {
+      type: 'raster',
+      tiles: [
+        'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+      ],
+      tileSize: 256,
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }
+  },
+  layers: [
+    {
+      id: 'osm-tiles',
+      type: 'raster',
+      source: 'osm-tiles',
+      minzoom: 0,
+      maxzoom: 19
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- add a new `osmStyle` that references raster tiles from tile.openstreetmap.org
- update all map components to import and use this style
- remove the previous WMS-based style causing image loading errors

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685fa860abe88332b673c56c553564f8