### PR TITLE
Enhance map category filtering

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -30,16 +30,18 @@ const functionIcons = {
 };
 
 // Create a composite icon element based on group and nodeFunction
-const getCompositeIcon = (group, nodeFunction) => {
+// Additional size and opacity params allow styling when filters are active
+const getCompositeIcon = (group, nodeFunction, size = 35, opacity = 1) => {
   const color = groupColors[group] || '#999';
   const icon = functionIcons[nodeFunction] || '📌';
 
   return (
     <div
       style={{
-        width: 35,
-        height: 35,
+        width: size,
+        height: size,
         backgroundColor: color,
+        opacity,
         borderRadius: '50%',
         display: 'flex',
         alignItems: 'center',
@@ -191,10 +193,13 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
           selectedCategory &&
           feature.properties &&
           feature.properties[selectedCategory.property] === selectedCategory.value;
+        const hasFilter = !!selectedCategory;
+        const iconSize = hasFilter ? (highlight ? 40 : 25) : 35;
+        const iconOpacity = hasFilter ? (highlight ? 1 : 0.4) : 1;
         return (
           <Marker key={idx} longitude={lng} latitude={lat} anchor="center">
             <div style={{ position: 'relative' }}>
-              {getCompositeIcon(group, nodeFunction)}
+              {getCompositeIcon(group, nodeFunction, iconSize, iconOpacity)}
               {highlight && (
                 <div
                   style={{

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -76,7 +76,9 @@ const MapRoutingPage = () => {
   };
 
   const handleCategoryClick = (category) => {
-    setSelectedCategory(category);
+    setSelectedCategory((current) =>
+      current && current.value === category.value ? null : category
+    );
   };
 
   const handleInputClick = (inputType) => {
@@ -183,7 +185,11 @@ const MapRoutingPage = () => {
             {groups.map((category, index) => (
               <div
                 key={index}
-                className="map-category-item"
+                className={`map-category-item ${
+                  selectedCategory && selectedCategory.value === category.value
+                    ? 'active'
+                    : ''
+                }`}
                 onClick={() => handleCategoryClick(category)}
               >
                 <div className={`map-category-icon ${category.icon}`}>

--- a/src/styles/MapRouting.css
+++ b/src/styles/MapRouting.css
@@ -87,6 +87,7 @@
   background-color: white;
   border-radius: 20px;
   font-family: 'Vazir', Arial, sans-serif;
+  cursor: pointer;
 }
 
 .map-category-item.active {


### PR DESCRIPTION
## Summary
- improve composite icon to allow size and opacity
- update markers to scale and fade when filter active
- toggle filter selection on repeated clicks
- highlight active category buttons
- add pointer cursor for category buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686142d3ea348332b68b2aa498cfcf33