### PR TITLE
Enable multilingual placeholders and buttons

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -36,4 +36,17 @@
   ,"logoutTitle": "خروج"
   ,"logoutAccount": "خروج از حساب کاربری"
 
+  ,"commentPlaceholder": "دیدگاه خود را بنویسید...",
+  ,"commentModalTitle": "دیدگاه و نظر خود را بنویسید",
+  ,"commentModalInstruction": "دیدگاه خودتان را که مربوط به این مکان می‌باشد را بنویسید. پس از تایید شدن، دیدگاه شما منتشر خواهد شد.",
+  ,"ratingPrompt": "امتیاز دهید:",
+  ,"submitComment": "ارسال و ثبت دیدگاه",
+  ,"searchPlaceholder": "کجا میخوای بری؟",
+  ,"originPlaceholder": "مبدا را انتخاب کنید",
+  ,"destinationPlaceholder": "مقصد را انتخاب کنید",
+  ,"destinationSearchPlaceholder": "جستجوی مقصد",
+  ,"originSearchPlaceholder": "جستجوی مبدا",
+  ,"chooseFromMap": "انتخاب از روی نقشه",
+  ,"emergencyPlaceholder": "توضیحات بیشتر...",
+  ,"emergencySubmit": "تایید و ارسال درخواست"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,4 +36,17 @@
   ,"logoutTitle": "Logout"
   ,"logoutAccount": "Sign out"
 
+  ,"commentPlaceholder": "Write your comment...",
+  ,"commentModalTitle": "Write your opinion",
+  ,"commentModalInstruction": "Write your comment about this place. After approval, your comment will be published.",
+  ,"ratingPrompt": "Rate:",
+  ,"submitComment": "Submit Comment",
+  ,"searchPlaceholder": "Where do you want to go?",
+  ,"originPlaceholder": "Select origin",
+  ,"destinationPlaceholder": "Select destination",
+  ,"destinationSearchPlaceholder": "Search destination",
+  ,"originSearchPlaceholder": "Search origin",
+  ,"chooseFromMap": "Choose from map",
+  ,"emergencyPlaceholder": "More details...",
+  ,"emergencySubmit": "Confirm and send request"
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -36,4 +36,17 @@
   ,"logoutTitle": "خروج"
   ,"logoutAccount": "خروج از حساب کاربری"
 
+  ,"commentPlaceholder": "دیدگاه خود را بنویسید...",
+  ,"commentModalTitle": "دیدگاه و نظر خود را بنویسید",
+  ,"commentModalInstruction": "دیدگاه خودتان را که مربوط به این مکان می‌باشد را بنویسید. پس از تایید شدن، دیدگاه شما منتشر خواهد شد.",
+  ,"ratingPrompt": "امتیاز دهید:",
+  ,"submitComment": "ارسال و ثبت دیدگاه",
+  ,"searchPlaceholder": "کجا میخوای بری؟",
+  ,"originPlaceholder": "مبدا را انتخاب کنید",
+  ,"destinationPlaceholder": "مقصد را انتخاب کنید",
+  ,"destinationSearchPlaceholder": "جستجوی مقصد",
+  ,"originSearchPlaceholder": "جستجوی مبدا",
+  ,"chooseFromMap": "انتخاب از روی نقشه",
+  ,"emergencyPlaceholder": "توضیحات بیشتر...",
+  ,"emergencySubmit": "تایید و ارسال درخواست"
 }

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -36,4 +36,17 @@
   ,"logoutTitle": "خروج"
   ,"logoutAccount": "خروج از حساب کاربری"
 
+  ,"commentPlaceholder": "دیدگاه خود را بنویسید...",
+  ,"commentModalTitle": "دیدگاه و نظر خود را بنویسید",
+  ,"commentModalInstruction": "دیدگاه خودتان را که مربوط به این مکان می‌باشد را بنویسید. پس از تایید شدن، دیدگاه شما منتشر خواهد شد.",
+  ,"ratingPrompt": "امتیاز دهید:",
+  ,"submitComment": "ارسال و ثبت دیدگاه",
+  ,"searchPlaceholder": "کجا میخوای بری؟",
+  ,"originPlaceholder": "مبدا را انتخاب کنید",
+  ,"destinationPlaceholder": "مقصد را انتخاب کنید",
+  ,"destinationSearchPlaceholder": "جستجوی مقصد",
+  ,"originSearchPlaceholder": "جستجوی مبدا",
+  ,"chooseFromMap": "انتخاب از روی نقشه",
+  ,"emergencyPlaceholder": "توضیحات بیشتر...",
+  ,"emergencySubmit": "تایید و ارسال درخواست"
 }

--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -3,9 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import '../styles/Location.css';
 import { groups } from '../components/groupData';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 const Location = () => {
   const navigate = useNavigate();
+  const intl = useIntl();
   const [activeSlide, setActiveSlide] = useState(0);
   const [comment, setComment] = useState('');
   const [comments, setComments] = useState([]);
@@ -346,7 +348,7 @@ const Location = () => {
           <div className="comment-input-container">
             <input
               type="text"
-              placeholder="دیدگاه خود را بنویسید..."
+              placeholder={intl.formatMessage({ id: 'commentPlaceholder' })}
               readOnly
             />
             <button type="button" className="send-comment">
@@ -441,13 +443,15 @@ const Location = () => {
 
               <div className="modal-comment-input">
                 <textarea
-                  placeholder="دیدگاه خود را بنویسید..."
+                  placeholder={intl.formatMessage({ id: 'commentPlaceholder' })}
                   value={comment}
                   onChange={(e) => setComment(e.target.value)}
                 ></textarea>
               </div>
 
-              <button className="submit-comment" onClick={handleCommentSubmit}> ارسال و ثبت دیدگاه</button>
+              <button className="submit-comment" onClick={handleCommentSubmit}>
+                <FormattedMessage id="submitComment" />
+              </button>
             </div>
           </div>
         </>
@@ -470,7 +474,7 @@ const Location = () => {
 
           <input
             type="text"
-            placeholder="کجا میخوای بری؟"
+            placeholder={intl.formatMessage({ id: 'searchPlaceholder' })}
             value={searchQuery}
             onChange={handleSearchChange}
             onFocus={handleSearchFocus}
@@ -484,7 +488,7 @@ const Location = () => {
                 <path stroke="none" d="M0 0h24v24H0z" fill="none" />
                 <path d="M18.364 4.636a9 9 0 0 1 .203 12.519l-.203 .21l-4.243 4.242a3 3 0 0 1 -4.097 .135l-.144 -.135l-4.244 -4.243a9 9 0 0 1 12.728 -12.728zm-6.364 3.364a3 3 0 1 0 0 6a3 3 0 0 0 0 -6z" />
               </svg>
-              <span>نقشه</span>
+              <span><FormattedMessage id="map" /></span>
             </button>
           ) : (
             <button
@@ -826,7 +830,7 @@ const Location = () => {
 
                 <input
                   type="text"
-                  placeholder="کجا میخوای بری؟"
+                  placeholder={intl.formatMessage({ id: 'searchPlaceholder' })}
                   value={searchQuery}
                   onChange={handleSearchChange}
                   autoFocus

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { FormattedMessage, useIntl } from 'react-intl';
 import MapComponent from '../components/map/MapComponent';
 import { groups } from '../components/groupData';
 import { useRouteStore } from '../store/routeStore';
@@ -7,6 +8,7 @@ import '../styles/MapRouting.css';
 
 const MapRoutingPage = () => {
   const navigate = useNavigate();
+  const intl = useIntl();
   const [showDestinationModal, setShowDestinationModal] = useState(false);
   const [showOriginModal, setShowOriginModal] = useState(false);
   const [selectedDestination, setSelectedDestination] = useState(null);
@@ -357,7 +359,7 @@ const MapRoutingPage = () => {
                   <input
                     type="text"
                     className="map-origin-input"
-                    placeholder="مبدا را انتخاب کنید"
+                    placeholder={intl.formatMessage({ id: 'originPlaceholder' })}
                     readOnly
                   />
                 )}
@@ -383,7 +385,7 @@ const MapRoutingPage = () => {
             >
               <input
                 type="text"
-                placeholder="مقصد را انتخاب کنید"
+                placeholder={intl.formatMessage({ id: 'destinationPlaceholder' })}
                 value={selectedDestination ? selectedDestination.name : ''}
                 readOnly
               />
@@ -402,7 +404,11 @@ const MapRoutingPage = () => {
               </button>
               <input
                 type="text"
-                placeholder={activeInput === 'destination' ? "جستجوی مقصد" : "جستجوی مبدا"}
+                placeholder={
+                  activeInput === 'destination'
+                    ? intl.formatMessage({ id: 'destinationSearchPlaceholder' })
+                    : intl.formatMessage({ id: 'originSearchPlaceholder' })
+                }
                 value={searchQuery}
                 onChange={handleInputChange}
                 autoFocus
@@ -426,7 +432,9 @@ const MapRoutingPage = () => {
                 <div className="map-option-icon">
                   <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#1E90FF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-photo-pin"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M15 8h.01" /><path d="M12.5 21h-6.5a3 3 0 0 1 -3 -3v-12a3 3 0 0 1 3 -3h12a3 3 0 0 1 3 3v5.5" /><path d="M3 16l5 -5c.928 -.893 2.072 -.893 3 0l2.5 2.5" /><path d="M21.121 20.121a3 3 0 1 0 -4.242 0c.418 .419 1.125 1.045 2.121 1.879c1.051 -.89 1.759 -1.516 2.121 -1.879z" /><path d="M19 18v.01" /></svg>
                 </div>
-                <span className="map-option-text">انتخاب از روی نقشه</span>
+                <span className="map-option-text">
+                  <FormattedMessage id="chooseFromMap" />
+                </span>
               </div>
               {isGPSEnabled && activeInput === 'origin' && (
                 <div className="map-option-item" onClick={handleCurrentLocationSelect}>

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { FormattedMessage, useIntl } from 'react-intl';
 import RouteMap from '../components/map/RouteMap';
 import '../styles/Routing.css';
 
 const RoutingPage = () => {
+  const intl = useIntl();
   const [isMapModalOpen, setIsMapModalOpen] = useState(true);
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(true);
   const [routeData, setRouteData] = useState(null);
@@ -318,11 +320,14 @@ const RoutingPage = () => {
             </div>
 
             <div className="emergency-description">
-              <textarea placeholder="توضیحات بیشتر..." className="emergency-textarea" />
+              <textarea
+                placeholder={intl.formatMessage({ id: 'emergencyPlaceholder' })}
+                className="emergency-textarea"
+              />
             </div>
 
             <button className="emergency-submit-button">
-              تایید و ارسال درخواست
+              <FormattedMessage id="emergencySubmit" />
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add new translation strings for form placeholders
- update Location, MapRouting and Routing pages to use `react-intl`
- show map button text via translator

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68615ca31b4883328c961f4f59502886