### PR TITLE
Fix label translation in location categories

### DIFF
--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -591,7 +591,7 @@ const Location = () => {
                     onClick={() => handleCategoryClick(category)}
                   >
                     <div className="category-icon" dangerouslySetInnerHTML={{ __html: category.svg }} />
-                    <span>{category.label}</span>
+                    <span>{intl.formatMessage({ id: category.label })}</span>
                   </div>
                 ))}
                 {showAllCategories && additionalCategories.map((category, index) => (
@@ -601,7 +601,7 @@ const Location = () => {
                     onClick={() => handleCategoryClick(category)}
                   >
                     <div className="category-icon" dangerouslySetInnerHTML={{ __html: category.svg }} />
-                    <span>{category.label}</span>
+                    <span>{intl.formatMessage({ id: category.label })}</span>
                   </div>
                 ))}
                 {showAllCategories &&


### PR DESCRIPTION
## Summary
- ensure category labels from groupData use `intl.formatMessage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862543c68488332becfd6cbc63883e4