### PR TITLE
Fix fetch paths for GitHub Pages

### DIFF
--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -46,7 +46,7 @@ const Location = () => {
 
   // Fetch routingData.json from public folder
   useEffect(() => {
-    fetch('/data/routing-data.json')
+    fetch(`${import.meta.env.BASE_URL}data/routing-data.json`)
       .then(res => res.json())
       .then(data => setRoutingData(data))
       .catch(err => console.error('Failed to load routing-data.json', err));
@@ -233,7 +233,7 @@ const Location = () => {
   useEffect(() => {
     const fetchLocationData = async () => {
       try {
-        const response = await axios.get('/data/locationData.json');
+        const response = await axios.get(`${import.meta.env.BASE_URL}data/locationData.json`);
         setLocationData(response.data);
         setComments(response.data.comments || []);
         setViews(response.data.views || 0);


### PR DESCRIPTION
## Summary
- ensure fetch paths use Vite base url

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686263680ba883329b3c8abe7668531c