### PR TITLE
Add named instructions and map zoom

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -12,7 +12,8 @@ const RouteMap = ({
   currentStep,
   isInfoModalOpen,
   isMapModalOpen,
-  is3DView
+  is3DView,
+  routeGeo
 }) => {
   const mapRef = useRef(null);
   const center = userLocation && userLocation.length === 2
@@ -46,6 +47,24 @@ const RouteMap = ({
       });
     }
   }, [is3DView]);
+
+  // Zoom to current segment when step changes
+  useEffect(() => {
+    if (
+      mapRef.current &&
+      routeGeo &&
+      currentStep < routeGeo.geometry.coordinates.length - 1
+    ) {
+      const start = routeGeo.geometry.coordinates[currentStep];
+      const end = routeGeo.geometry.coordinates[currentStep + 1];
+      const bounds = new maplibregl.LngLatBounds(
+        [start[0], start[1]],
+        [start[0], start[1]]
+      );
+      bounds.extend([end[0], end[1]]);
+      mapRef.current.fitBounds(bounds, { padding: 80, duration: 700 });
+    }
+  }, [currentStep, routeGeo]);
 
   return (
     <Map

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -491,6 +491,7 @@ const RoutingPage = () => {
               isInfoModalOpen={isInfoModalOpen}
               isMapModalOpen={isMapModalOpen}
               is3DView={is3DView}
+              routeGeo={routeGeo}
             />
           </div>
         )}

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -34,22 +34,42 @@ export function analyzeRoute(origin, destination, geoData) {
 
   if (startDoor) {
     path.push(startDoor.slice(0, 2));
-    steps.push({ coordinates: startDoor.slice(0, 2), instruction: 'حرکت به سمت نزدیک‌ترین درب' });
+    const name = startDoor[2]?.name ? ` (${startDoor[2].name})` : '';
+    steps.push({
+      coordinates: startDoor.slice(0, 2),
+      instruction: `حرکت به سمت درب${name}`
+    });
   }
   if (startConn) {
     path.push(startConn.slice(0, 2));
-    steps.push({ coordinates: startConn.slice(0, 2), instruction: 'عبور از نقطه اتصال' });
+    const title = startConn[2]?.subGroup || startConn[2]?.name || '';
+    steps.push({
+      coordinates: startConn.slice(0, 2),
+      instruction: `عبور از نقطه اتصال ${title}`.trim()
+    });
   }
   if (endConn && (!startConn || endConn[0] !== startConn[0] || endConn[1] !== startConn[1])) {
     path.push(endConn.slice(0, 2));
-    steps.push({ coordinates: endConn.slice(0, 2), instruction: 'ورود به صحن بعدی از طریق نقطه اتصال' });
+    const title = endConn[2]?.subGroup || endConn[2]?.name || '';
+    steps.push({
+      coordinates: endConn.slice(0, 2),
+      instruction: `ورود به صحن بعدی از طریق نقطه اتصال ${title}`.trim()
+    });
   }
   if (endDoor) {
     path.push(endDoor.slice(0, 2));
-    steps.push({ coordinates: endDoor.slice(0, 2), instruction: 'عبور از درب' });
+    const name = endDoor[2]?.name ? ` (${endDoor[2].name})` : '';
+    steps.push({
+      coordinates: endDoor.slice(0, 2),
+      instruction: `عبور از درب${name}`
+    });
   }
   path.push(destination.coordinates);
-  steps.push({ coordinates: destination.coordinates, instruction: 'رسیدن به مقصد' });
+  const destName = destination.name ? ` (${destination.name})` : '';
+  steps.push({
+    coordinates: destination.coordinates,
+    instruction: `رسیدن به مقصد${destName}`
+  });
 
   const geo = {
     type: 'Feature',


### PR DESCRIPTION
## Summary
- show feature titles for steps in `analyzeRoute`
- zoom map to each path segment in `RouteMap`
- pass `routeGeo` to `RouteMap`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628ccd9108833284d3d61d335ed972