### PR TITLE
Add GeoJSON overlay on route details page

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -258,6 +258,7 @@ const FinalSearch = () => {
               <Layer id="main-line" type="line" paint={{ 'line-color': '#2196F3', 'line-width': 6 }} />
             </Source>
           )}
+          <GeoJsonOverlay />
         </Map>
       </div>
 


### PR DESCRIPTION
## Summary
- show `GeoJsonOverlay` component on the FinalSearch map

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68628b8604388332aa856b9faa67c1ce