### PR TITLE
Add default comment author key

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -59,6 +59,7 @@
   "nearMe": "الأماكن القريبة مني",
   "save": "حفظ",
   "commentsLabel": "تعليق",
+  "defaultCommentAuthor": "مستخدم جديد",
   "searchSuggestions": "اقتراحات البحث",
   "loading": "جار التحميل...",
   "fetchError": "خطأ في جلب البيانات: {error}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,6 +59,7 @@
   ,"nearMe": "Places near me"
   ,"save": "Save"
   ,"commentsLabel": "comments"
+  ,"defaultCommentAuthor": "New user"
   ,"searchSuggestions": "Search suggestions"
   ,"loading": "Loading..."
   ,"fetchError": "Error fetching data: {error}"

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -59,6 +59,7 @@
   ,"nearMe": "مکان‌های نزدیک من"
   ,"save": "ذخیره"
   ,"commentsLabel": "نظر"
+  ,"defaultCommentAuthor": "کاربر جدید"
   ,"searchSuggestions": "پیشنهاد‌های جستجو"
   ,"loading": "در حال بارگذاری..."
   ,"fetchError": "خطا در دریافت اطلاعات: {error}"

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -59,6 +59,7 @@
   "nearMe": "میرے قریب مقامات",
   "save": "محفوظ کریں",
   "commentsLabel": "تبصرہ",
+  "defaultCommentAuthor": "نیا صارف",
   "searchSuggestions": "تلاش کی تجاویز",
   "loading": "لوڈ ہو رہا ہے...",
   "fetchError": "ڈیٹا حاصل کرنے میں خرابی: {error}",

--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -117,7 +117,7 @@ const Location = () => {
     e.preventDefault();
     if (comment.trim()) {
       const newComment = {
-        author: 'کاربر جدید',
+        author: intl.formatMessage({ id: 'defaultCommentAuthor' }),
         text: comment,
         date: new Date().toLocaleDateString('fa-IR'),
         rating: rating || 0


### PR DESCRIPTION
## Summary
- introduce `defaultCommentAuthor` in all locales
- use that key when submitting a comment in `Location.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68629f60d5448332a530ecf0b2379b8a