### PR TITLE
Use intl defaults for ProfileHeader

### DIFF
--- a/src/components/profile/ProfileHeader.jsx
+++ b/src/components/profile/ProfileHeader.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
-function ProfileHeader({ name = "کاربر مسیربایی", 
-                      location = "استان قدس", 
-                      phone = "+98-9123456789" }) {
+function ProfileHeader({ name, location, phone = "+98-9123456789" }) {
+  const intl = useIntl();
+  const displayName = name || intl.formatMessage({ id: 'defaultUserName' });
+  const displayLocation = location || intl.formatMessage({ id: 'defaultLocation' });
   return (
     <div className="profile-header">
       {/* Profile Picture with Add Button */}
@@ -15,8 +16,8 @@ function ProfileHeader({ name = "کاربر مسیربایی",
       </div>
 
       {/* User Information */}
-      <h3 className="profile-name">{name}</h3>
-      <p className="profile-location">{location}</p>
+      <h3 className="profile-name">{displayName}</h3>
+      <p className="profile-location">{displayLocation}</p>
       <p className="profile-phone">{phone}</p>
       
       {/* Complete Profile Button */}

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -135,6 +135,7 @@
   ,"metersPerSecond": "متر/ثانية"
   ,"degreesPerSecond": "درجة/ثانية"
   ,"defaultUserName": "مستخدم المسير"
+  ,"defaultLocation": "العتبة الرضوية"
   ,"defaultBabRezaName": "باب الرضا"
   ,"destSahnEnqelabName": "صحن الثورة"
   ,"destSahnEnqelabLocation": "العتبة الرضوية، صحن الثورة"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -135,6 +135,7 @@
   ,"metersPerSecond": "m/s"
   ,"degreesPerSecond": "deg/s"
   ,"defaultUserName": "Astan Quds User"
+  ,"defaultLocation": "Astan Quds Razavi"
   ,"defaultBabRezaName": "Bab al-Reza Gate"
   ,"destSahnEnqelabName": "Sahn Enqelab"
   ,"destSahnEnqelabLocation": "Imam Reza Shrine, Sahn Enqelab"

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -135,6 +135,7 @@
   ,"metersPerSecond": "متر بر ثانیه"
   ,"degreesPerSecond": "درجه بر ثانیه"
   ,"defaultUserName": "کاربر مسیربایی آستان قدس"
+  ,"defaultLocation": "آستان قدس رضوی"
   ,"defaultBabRezaName": "باب الرضا (ع)"
   ,"destSahnEnqelabName": "صحن انقلاب"
   ,"destSahnEnqelabLocation": "حرم مطهر امام رضا علیه‌السلام، صحن انقلاب"

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -135,6 +135,7 @@
   ,"metersPerSecond": "میٹر فی سیکنڈ"
   ,"degreesPerSecond": "ڈگری فی سیکنڈ"
   ,"defaultUserName": "راستہ صارف"
+  ,"defaultLocation": "آستان قدس"
   ,"defaultBabRezaName": "باب الرضا"
   ,"destSahnEnqelabName": "صحن انقلاب"
   ,"destSahnEnqelabLocation": "امام رضا حرم، صحن انقلاب"


### PR DESCRIPTION
## Summary
- add `defaultLocation` translations
- use `intl.formatMessage` for ProfileHeader default props

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68629f60b9b48332b1f5261de508c2dd