### PR TITLE
Improve routing algorithm

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -23,7 +23,8 @@ const FinalSearch = () => {
     setOrigin: storeSetOrigin,
     setDestination: storeSetDestination,
     setRouteGeo: storeSetRouteGeo,
-    setRouteSteps: storeSetRouteSteps
+    setRouteSteps: storeSetRouteSteps,
+    setAlternativeRoutes: storeSetAlternativeRoutes
   } = useRouteStore();
   const language = useLangStore((state) => state.language);
   const [origin, setOrigin] = useState(
@@ -103,10 +104,11 @@ const FinalSearch = () => {
 
   useEffect(() => {
     if (!geoData) return;
-    const { geo, steps } = analyzeRoute(origin, destination, geoData);
+    const { geo, steps, alternatives } = analyzeRoute(origin, destination, geoData);
     storeSetRouteGeo(geo);
     storeSetRouteSteps(steps);
-  }, [geoData, origin, destination, storeSetRouteGeo, storeSetRouteSteps]);
+    storeSetAlternativeRoutes(alternatives);
+  }, [geoData, origin, destination, storeSetRouteGeo, storeSetRouteSteps, storeSetAlternativeRoutes]);
 
   const swapLocations = () => {
     setSwapButton(!isSwapButton);

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -24,7 +24,7 @@ const RoutingPage = () => {
   const [was3DViewBeforeRouteView, setWas3DViewBeforeRouteView] = useState(false);
   const [is3DView, setIs3DView] = useState(false);
   const navigate = useNavigate();
-  const { routeSteps, routeGeo } = useRouteStore();
+  const { routeSteps, routeGeo, alternativeRoutes } = useRouteStore();
 
   // Calculate total time in minutes from all steps
   const calculateTotalTime = (steps) => {
@@ -99,14 +99,40 @@ const RoutingPage = () => {
     const arrivalTime = calculateArrivalTime(totalMinutes);
     const totalDistance = steps.reduce((acc, st) => acc + parseInt(st.distance), 0);
 
+    const alternativesData = (alternativeRoutes || []).map((alt, ridx) => {
+      const altSteps = alt.steps.map((st, i) => {
+        let dist = 0;
+        if (i > 0) {
+          const [lng1, lat1] = alt.geo.geometry.coordinates[i - 1];
+          const [lng2, lat2] = alt.geo.geometry.coordinates[i];
+          dist = Math.hypot(lng2 - lng1, lat2 - lat1) * 100000;
+        }
+        return {
+          id: i + 1,
+          instruction: intl.formatMessage({ id: st.type }, { name: st.name, title: st.title, num: i + 1 }),
+          distance: `${Math.round(dist)} متر`,
+          time: `${Math.max(1, Math.round(dist / 60))} دقیقه`,
+          coordinates: st.coordinates
+        };
+      });
+      const minutes = calculateTotalTime(altSteps);
+      const distTot = altSteps.reduce((acc, st) => acc + parseInt(st.distance), 0);
+      return {
+        id: ridx + 1,
+        steps: altSteps,
+        totalTime: formatTotalTime(minutes),
+        totalDistance: `${distTot} متر`
+      };
+    });
+
     setRouteData({
       steps,
       totalTime: formattedTotalTime,
       arrivalTime,
       totalDistance: `${totalDistance} متر`,
-      alternativeRoutes: []
+      alternativeRoutes: alternativesData
     });
-  }, [routeSteps, routeGeo]);
+  }, [routeSteps, routeGeo, alternativeRoutes]);
 
   // Update arrival time every minute
   useEffect(() => {

--- a/src/store/routeStore.js
+++ b/src/store/routeStore.js
@@ -8,11 +8,14 @@ export const useRouteStore = create(
       destination: null,
       routeGeo: null,
       routeSteps: [],
+      alternativeRoutes: [],
       setOrigin: (origin) => set({ origin }),
       setDestination: (destination) => set({ destination }),
       setRouteGeo: (routeGeo) => set({ routeGeo }),
       setRouteSteps: (routeSteps) => set({ routeSteps }),
-      clearRoute: () => set({ origin: null, destination: null, routeGeo: null, routeSteps: [] })
+      setAlternativeRoutes: (alternativeRoutes) => set({ alternativeRoutes }),
+      clearRoute: () =>
+        set({ origin: null, destination: null, routeGeo: null, routeSteps: [], alternativeRoutes: [] })
     }),
     {
       name: 'route-storage',

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -7,10 +7,33 @@ export function findNearest(coord, features) {
     const d = Math.hypot(lng - coord[1], lat - coord[0]);
     if (d < min) {
       min = d;
-      best = [lat, lng, f.properties];
+      best = [lat, lng, f.properties, d];
     }
   });
   return best;
+}
+
+function findNearestList(coord, features, count = 2) {
+  if (!features || features.length === 0) return [];
+  return features
+    .map(f => {
+      const [lng, lat] = f.geometry.coordinates;
+      const d = Math.hypot(lng - coord[1], lat - coord[0]);
+      return { lat, lng, props: f.properties, distance: d };
+    })
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, count)
+    .map(r => [r.lat, r.lng, r.props, r.distance]);
+}
+
+function angleBetween(p1, p2, p3) {
+  const toRad = deg => (deg * Math.PI) / 180;
+  const a1 = Math.atan2(p2[0] - p1[0], p2[1] - p1[1]);
+  const a2 = Math.atan2(p3[0] - p2[0], p3[1] - p2[1]);
+  let deg = ((a2 - a1) * 180) / Math.PI;
+  if (deg > 180) deg -= 360;
+  if (deg < -180) deg += 360;
+  return Math.round(deg);
 }
 
 export function analyzeRoute(origin, destination, geoData) {
@@ -24,11 +47,25 @@ export function analyzeRoute(origin, destination, geoData) {
     f => f.geometry.type === 'Point' && f.properties?.nodeFunction === 'connection'
   );
 
-  const startDoor = findNearest(origin.coordinates, doors);
-  const endDoor = findNearest(destination.coordinates, doors);
+  const DOOR_THRESHOLD = 0.0008; // ~80m
 
-  const startConn = startDoor ? findNearest(startDoor, connections) : null;
-  const endConn = endDoor ? findNearest(endDoor, connections) : null;
+  function pickAccess(coord) {
+    const nearestDoor = findNearest(coord, doors);
+    if (nearestDoor && nearestDoor[3] < DOOR_THRESHOLD) {
+      const conn = findNearest(nearestDoor, connections);
+      return { door: nearestDoor, conn };
+    }
+    const conn = findNearest(coord, connections);
+    return { door: null, conn };
+  }
+
+  const startAccess = pickAccess(origin.coordinates);
+  const endAccess = pickAccess(destination.coordinates);
+
+  const startDoor = startAccess.door;
+  const endDoor = endAccess.door;
+  const startConn = startAccess.conn;
+  const endConn = endAccess.conn;
 
   const path = [origin.coordinates];
   const steps = [];
@@ -76,10 +113,56 @@ export function analyzeRoute(origin, destination, geoData) {
 
   });
 
+  // compute approximate turn angles
+  for (let i = 1; i < path.length - 1; i++) {
+    const angle = angleBetween(path[i - 1], path[i], path[i + 1]);
+    if (steps[i - 1]) {
+      steps[i - 1].turnAngle = angle;
+    }
+  }
+
   const geo = {
     type: 'Feature',
     geometry: { type: 'LineString', coordinates: path.map(p => [p[1], p[0]]) }
   };
 
-  return { path, geo, steps };
+  const alternatives = [];
+  const altStartDoor = findNearestList(origin.coordinates, doors, 2)[1];
+  const altEndDoor = findNearestList(destination.coordinates, doors, 2)[1];
+
+  if (altStartDoor || altEndDoor) {
+    const altStartConn = altStartDoor ? findNearest(altStartDoor, connections) : findNearest(origin.coordinates, connections);
+    const altEndConn = altEndDoor ? findNearest(altEndDoor, connections) : findNearest(destination.coordinates, connections);
+    const altPath = [origin.coordinates];
+    const altSteps = [];
+    if (altStartDoor) {
+      altPath.push(altStartDoor.slice(0, 2));
+      altSteps.push({ coordinates: altStartDoor.slice(0, 2), type: 'stepMoveToDoor', name: altStartDoor[2]?.name || '' });
+    }
+    if (altStartConn) {
+      altPath.push(altStartConn.slice(0, 2));
+      altSteps.push({ coordinates: altStartConn.slice(0, 2), type: 'stepPassConnection', title: altStartConn[2]?.subGroup || altStartConn[2]?.name || '' });
+    }
+    if (altEndConn && (!altStartConn || altEndConn[0] !== altStartConn[0] || altEndConn[1] !== altStartConn[1])) {
+      altPath.push(altEndConn.slice(0, 2));
+      altSteps.push({ coordinates: altEndConn.slice(0, 2), type: 'stepEnterNextSahn', title: altEndConn[2]?.subGroup || altEndConn[2]?.name || '' });
+    }
+    if (altEndDoor) {
+      altPath.push(altEndDoor.slice(0, 2));
+      altSteps.push({ coordinates: altEndDoor.slice(0, 2), type: 'stepPassDoor', name: altEndDoor[2]?.name || '' });
+    }
+    altPath.push(destination.coordinates);
+    altSteps.push({ coordinates: destination.coordinates, type: 'stepArriveDestination', name: destination.name || '' });
+    for (let i = 1; i < altPath.length - 1; i++) {
+      const angle = angleBetween(altPath[i - 1], altPath[i], altPath[i + 1]);
+      if (altSteps[i - 1]) altSteps[i - 1].turnAngle = angle;
+    }
+    const altGeo = {
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: altPath.map(p => [p[1], p[0]]) }
+    };
+    alternatives.push({ path: altPath, geo: altGeo, steps: altSteps });
+  }
+
+  return { path, geo, steps, alternatives };
 }


### PR DESCRIPTION
## Summary
- extend route store to hold alternative routes
- compute angles, fallback connections, and alternative paths in `analyzeRoute`
- save alternative routes when computing a route
- show alternative routes and use them in the UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68629cecc6508332ada409df87bf45d8