### PR TITLE
Add door adjacency checks to routing

### DIFF
--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -26,6 +26,25 @@ function findNearestList(coord, features, count = 2) {
     .map(r => [r.lat, r.lng, r.props, r.distance]);
 }
 
+function pointInPolygon(point, polygons) {
+  const x = point[1];
+  const y = point[0];
+  const polyList = Array.isArray(polygons[0][0]) && typeof polygons[0][0][0] === 'number' ? [polygons] : polygons;
+  for (const poly of polyList) {
+    let inside = false;
+    for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+      const xi = poly[i][0];
+      const yi = poly[i][1];
+      const xj = poly[j][0];
+      const yj = poly[j][1];
+      const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+      if (intersect) inside = !inside;
+    }
+    if (inside) return true;
+  }
+  return false;
+}
+
 function angleBetween(p1, p2, p3) {
   const a1 = Math.atan2(p2[0] - p1[0], p2[1] - p1[1]);
   const a2 = Math.atan2(p3[0] - p2[0], p3[1] - p2[1]);
@@ -45,14 +64,28 @@ export function analyzeRoute(origin, destination, geoData) {
   const connections = geoData.features.filter(
     f => f.geometry.type === 'Point' && f.properties?.nodeFunction === 'connection'
   );
+  const sahnPolygons = geoData.features.filter(
+    f => f.geometry.type === 'Polygon' && f.properties?.subGroupValue?.startsWith('sahn-')
+  );
 
   const DOOR_THRESHOLD = 0.0008; // ~80m
+  const DOOR_CONN_THRESHOLD = 0.0004; // ~40m to ensure adjacency
+
+  function isPointInSahn(coord) {
+    return sahnPolygons.some(p => pointInPolygon(coord, p.geometry.coordinates));
+  }
 
   function pickAccess(coord) {
     const nearestDoor = findNearest(coord, doors);
-    if (nearestDoor && nearestDoor[3] < DOOR_THRESHOLD) {
+    if (nearestDoor && (nearestDoor[3] < DOOR_THRESHOLD || isPointInSahn(coord))) {
       const conn = findNearest(nearestDoor, connections);
-      return { door: nearestDoor, conn };
+      if (
+        conn &&
+        conn[3] < DOOR_CONN_THRESHOLD &&
+        (conn[2]?.subGroupValue === 'saایر' || conn[2]?.subGroupValue === nearestDoor[2]?.subGroupValue)
+      ) {
+        return { door: nearestDoor, conn };
+      }
     }
     const conn = findNearest(coord, connections);
     return { door: null, conn };
@@ -130,8 +163,22 @@ export function analyzeRoute(origin, destination, geoData) {
   const altEndDoor = findNearestList(destination.coordinates, doors, 2)[1];
 
   if (altStartDoor || altEndDoor) {
-    const altStartConn = altStartDoor ? findNearest(altStartDoor, connections) : findNearest(origin.coordinates, connections);
-    const altEndConn = altEndDoor ? findNearest(altEndDoor, connections) : findNearest(destination.coordinates, connections);
+    const startConnCandidate = altStartDoor ? findNearest(altStartDoor, connections) : null;
+    const altStartConn =
+      startConnCandidate &&
+      startConnCandidate[3] < DOOR_CONN_THRESHOLD &&
+      (startConnCandidate[2]?.subGroupValue === 'saایر' ||
+        startConnCandidate[2]?.subGroupValue === altStartDoor[2]?.subGroupValue)
+        ? startConnCandidate
+        : findNearest(origin.coordinates, connections);
+    const endConnCandidate = altEndDoor ? findNearest(altEndDoor, connections) : null;
+    const altEndConn =
+      endConnCandidate &&
+      endConnCandidate[3] < DOOR_CONN_THRESHOLD &&
+      (endConnCandidate[2]?.subGroupValue === 'saایر' ||
+        endConnCandidate[2]?.subGroupValue === altEndDoor[2]?.subGroupValue)
+        ? endConnCandidate
+        : findNearest(destination.coordinates, connections);
     const altPath = [origin.coordinates];
     const altSteps = [];
     if (altStartDoor) {


### PR DESCRIPTION
## Summary
- improve routing logic to avoid jumping across non-adjacent areas
- force entry or exit from courtyards via doors near the same area

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862a6fa75108332b7b2ceec7ffdcea1