### PR TITLE
Implement Dijkstra based routing

### DIFF
--- a/tests/routeAnalysis.test.js
+++ b/tests/routeAnalysis.test.js
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import fs from 'fs';
+import { computeShortestPath } from '../src/utils/routeAnalysis.js';
+
+const geo = JSON.parse(fs.readFileSync(new URL('./sample.geojson', import.meta.url)));
+
+const origin = { coordinates: [-0.5, 0] };
+const destination = { coordinates: [2.5, 0] };
+
+const { path } = computeShortestPath(origin, destination, geo.features);
+
+assert.strictEqual(path[0][0], origin.coordinates[0]);
+assert.strictEqual(path[path.length - 1][0], destination.coordinates[0]);
+assert.ok(path.length >= 3, 'path should include intermediate nodes');
+
+console.log('computeShortestPath test passed');

--- a/tests/sample.geojson
+++ b/tests/sample.geojson
@@ -1,0 +1,8 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{"nodeFunction":"door","name":"A"}},
+    {"type":"Feature","geometry":{"type":"Point","coordinates":[1,0]},"properties":{"nodeFunction":"connection","name":"X"}},
+    {"type":"Feature","geometry":{"type":"Point","coordinates":[2,0]},"properties":{"nodeFunction":"door","name":"D"}}
+  ]
+}


### PR DESCRIPTION
## Summary
- implement `computeShortestPath` with basic Dijkstra search
- update `analyzeRoute` to use the new path finder
- add a minimal test using a toy GeoJSON sample

## Testing
- `node tests/routeAnalysis.test.js`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6862f51e5d808332a2a02b37fd1055fe