### PR TITLE
Add QR code location session support

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -89,6 +89,18 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
   }, [selectedDestination]);
 
   useEffect(() => {
+    const storedLat = sessionStorage.getItem('qrLat');
+    const storedLng = sessionStorage.getItem('qrLng');
+    if (storedLat && storedLng) {
+      const c = { lat: parseFloat(storedLat), lng: parseFloat(storedLng) };
+      setUserCoords(c);
+      setUserLocation({
+        name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
+        coordinates: [c.lat, c.lng]
+      });
+      setViewState((v) => ({ ...v, latitude: c.lat, longitude: c.lng }));
+      return;
+    }
     const success = (pos) => {
       const c = { lat: pos.coords.latitude, lng: pos.coords.longitude };
       setUserCoords(c);
@@ -118,7 +130,7 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
       timeout: 10000
     });
     return () => navigator.geolocation.clearWatch(watchId);
-  }, [setUserLocation]);
+  }, [setUserLocation, intl]);
 
   useEffect(() => {
     if (isSwapped && userCoords && destCoords) {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,15 @@ import App from './App.jsx';
 import IntlProviderWrapper from './IntlProviderWrapper.jsx';
 import './index.css';
 
+// Check URL parameters for QR code location and store in session
+const params = new URLSearchParams(window.location.search);
+const lat = params.get('lat');
+const lng = params.get('lng');
+if (lat && lng) {
+  sessionStorage.setItem('qrLat', lat);
+  sessionStorage.setItem('qrLng', lng);
+}
+
 import { registerSW } from 'virtual:pwa-register';
 
 // Use the plugin's registration method instead of manual registration

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -14,10 +14,18 @@ const MapRoutingPage = () => {
   const [showDestinationModal, setShowDestinationModal] = useState(false);
   const [showOriginModal, setShowOriginModal] = useState(false);
   const [selectedDestination, setSelectedDestination] = useState(null);
-  const [userLocation, setUserLocation] = useState({
-    name: intl.formatMessage({ id: 'defaultBabRezaName' }),
-    coordinates: [36.297, 59.6069]
-  });
+  const storedLat = sessionStorage.getItem('qrLat');
+  const storedLng = sessionStorage.getItem('qrLng');
+  const initialUserLocation = storedLat && storedLng
+    ? {
+        name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
+        coordinates: [parseFloat(storedLat), parseFloat(storedLng)]
+      }
+    : {
+        name: intl.formatMessage({ id: 'defaultBabRezaName' }),
+        coordinates: [36.297, 59.6069]
+      };
+  const [userLocation, setUserLocation] = useState(initialUserLocation);
   const [searchQuery, setSearchQuery] = useState('');
   const [activeInput, setActiveInput] = useState(null);
   const [isGPSEnabled, setIsGPSEnabled] = useState(false);


### PR DESCRIPTION
## Summary
- capture QR code latitude/longitude from the page URL and persist in `sessionStorage`
- initialize `MapRouting` using the stored coordinates
- let `MapComponent` use stored coordinates instead of device geolocation when present

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node tests/routeAnalysis.test.js` *(fails: Cannot find package '@turf/boolean-point-in-polygon')*

------
https://chatgpt.com/codex/tasks/task_e_6863f140ceec8332ae4ce19a5df925d9