### PR TITLE
Use session QR coords as location

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -29,11 +29,19 @@ const FinalSearch = () => {
     setAlternativeRoutes: storeSetAlternativeRoutes
   } = useRouteStore();
   const language = useLangStore((state) => state.language);
+  const qrLat = sessionStorage.getItem('qrLat');
+  const qrLng = sessionStorage.getItem('qrLng');
   const [origin, setOrigin] = useState(
-    storedOrigin || {
-      name: intl.formatMessage({ id: 'defaultBabRezaName' }),
-      coordinates: [36.2970, 59.6069]
-    }
+    storedOrigin ||
+      (qrLat && qrLng
+        ? {
+            name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
+            coordinates: [parseFloat(qrLat), parseFloat(qrLng)]
+          }
+        : {
+            name: intl.formatMessage({ id: 'defaultBabRezaName' }),
+            coordinates: [36.2970, 59.6069]
+          })
   );
   const [destination, setDestination] = useState(
     storedDestination || {
@@ -69,9 +77,9 @@ const FinalSearch = () => {
     }
   }, [selectedTransport]);
 
-  // Fallback to current GPS coordinates if origin coords not provided
+  // Fallback to current GPS coordinates if origin coords not provided and no QR data
   useEffect(() => {
-    if (!origin.coordinates) {
+    if (!origin.coordinates && !(qrLat && qrLng)) {
       navigator.geolocation.getCurrentPosition(
         (pos) =>
           setOrigin((o) => ({
@@ -79,9 +87,9 @@ const FinalSearch = () => {
             coordinates: [pos.coords.latitude, pos.coords.longitude]
           })),
         (err) => console.error('gps error', err)
-      );
+      )
     }
-  }, [origin.coordinates]);
+  }, [origin.coordinates, qrLat, qrLng])
 
   useEffect(() => {
     const file = buildGeoJsonPath(language);

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -11,7 +11,13 @@ const RoutingPage = () => {
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(true);
   const [routeData, setRouteData] = useState(null);
   const [currentStep, setCurrentStep] = useState(0);
-  const [userLocation, setUserLocation] = useState([36.2880, 59.6157]);
+  const storedLat = sessionStorage.getItem('qrLat');
+  const storedLng = sessionStorage.getItem('qrLng');
+  const [userLocation, setUserLocation] = useState(
+    storedLat && storedLng
+      ? [parseFloat(storedLat), parseFloat(storedLng)]
+      : [36.2880, 59.6157]
+  );
   const [showEmergencyModal, setShowEmergencyModal] = useState(false);
   const [showSoundModal, setShowSoundModal] = useState(false);
   const [selectedEmergency, setSelectedEmergency] = useState(null);
@@ -178,29 +184,31 @@ const RoutingPage = () => {
     return () => clearInterval(timer);
   }, [routeData]);
 
-  // Get user's current location
+  // Get user's current location only if no QR coordinates provided
   useEffect(() => {
-    if (navigator.geolocation) {
-      const options = {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 0
-      };
+    if (!storedLat || !storedLng) {
+      if (navigator.geolocation) {
+        const options = {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 0
+        }
 
-      const success = (position) => {
-        setUserLocation([position.coords.latitude, position.coords.longitude]);
-      };
+        const success = (position) => {
+          setUserLocation([position.coords.latitude, position.coords.longitude])
+        }
 
-      const error = (err) => {
-        console.warn(`ERROR(${err.code}): ${err.message}`);
-        setUserLocation([36.2880, 59.6157]);
-      };
+        const error = (err) => {
+          console.warn(`ERROR(${err.code}): ${err.message}`)
+          setUserLocation([36.2880, 59.6157])
+        }
 
-      const watchId = navigator.geolocation.watchPosition(success, error, options);
+        const watchId = navigator.geolocation.watchPosition(success, error, options)
 
-      return () => navigator.geolocation.clearWatch(watchId);
+        return () => navigator.geolocation.clearWatch(watchId)
+      }
     }
-  }, []);
+  }, [storedLat, storedLng])
 
   // Auto-advance steps when routing is active
   useEffect(() => {


### PR DESCRIPTION
## Summary
- store QR coordinates in `FinalSearch` and `Routing` pages
- prefer QR coordinates over GPS when available

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867c68b090c8332b8dba42e18637bbc