### PR TITLE
Integrate react-toastify notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
 		"react-map-gl": "^7.1.9",
 		"react-router-dom": "^6.30.0",
 		"uuid": "^9.0.1",
-		"validator": "^13.11.0",
-		"vazir-font": "^30.1.0",
-		"zustand": "^4.4.7"
+        "validator": "^13.11.0",
+        "vazir-font": "^30.1.0",
+        "zustand": "^4.4.7",
+        "react-toastify": "^9.1.3"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.30.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import Location from './pages/Location';
 import { Header } from './components/layout/Header';
 import { Footer } from './components/layout/Footer';
 import './App.css';
+import { ToastContainer } from 'react-toastify';
 
 const AppContent = () => {
   const location = useLocation();
@@ -97,6 +98,7 @@ const AppContent = () => {
 function App() {
   return (
     <Router>
+      <ToastContainer />
       <AppContent />
     </Router>
   );

--- a/src/components/map/DeadReckoningControls.jsx
+++ b/src/components/map/DeadReckoningControls.jsx
@@ -3,6 +3,8 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import advancedDeadReckoningService from '../../services/AdvancedDeadReckoningService';
 import useIMUSensors from '../../hooks/useIMUSensors';
 import './DeadReckoningControls.css';
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 const DeadReckoningControls = ({ currentLocation }) => {
   const [isActive, setIsActive] = useState(false);
@@ -33,7 +35,7 @@ const DeadReckoningControls = ({ currentLocation }) => {
 
       // اگر در حالت فعال سرویس و کالیبراسیون نیستیم ولی گام نرفته، alert بده  
       if (data.isActive && !data.isCalibrating && data.stepCount === 0 && !stepCountErrorShown) {
-        alert(intl.formatMessage({ id: 'drStepWarning' }));
+        toast.error(intl.formatMessage({ id: 'drStepWarning' }));
         setStepCountErrorShown(true);
       }
 
@@ -70,13 +72,13 @@ const DeadReckoningControls = ({ currentLocation }) => {
   const handleToggle = async () => {
     if (!isActive) {
       if (!isSupported) {
-        alert(intl.formatMessage({ id: 'drSensorsUnsupported' }));
+        toast.error(intl.formatMessage({ id: 'drSensorsUnsupported' }));
         return;
       }
 
       if (!checkPermissions()) {
         const ok = await requestPermission();
-        if (!ok) { alert(intl.formatMessage({ id: 'drPermissionNeeded' })); return; }
+        if (!ok) { toast.error(intl.formatMessage({ id: 'drPermissionNeeded' })); return; }
       }
 
       const initialLatLng = currentLocation?.coords ? {

--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -8,6 +8,8 @@ import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { useSearchStore } from '../store/searchStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 // Map subgroup labels to their values for easier lookup
 const labelToValueMap = Object.values(subGroups).flat().reduce((acc, sg) => {
@@ -230,7 +232,7 @@ const Location = () => {
       }
     }
     
-    alert(intl.formatMessage({ id: 'noDataFound' }));
+    toast.error(intl.formatMessage({ id: 'noDataFound' }));
   };
 
   const handleSearchFocus = () => {


### PR DESCRIPTION
## Summary
- add react-toastify dependency
- render ToastContainer in App
- import toast and styles in Location and DeadReckoningControls
- replace browser alert calls with toast notifications

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6867d32918fc83329069775fbae756a3