### PR TITLE
Improve Toastify RTL handling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1131,3 +1131,16 @@ body {
   border: none;
   color: #999;
 }
+
+/* Toastify Custom Styles */
+.custom-toast {
+  background-color: var(--primary-color);
+  color: #fff;
+  border-radius: var(--border-radius);
+  padding: 12px 16px;
+  text-align: start;
+}
+
+.custom-toast .Toastify__progress-bar {
+  background-color: var(--secondary-color);
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ import Location from './pages/Location';
 import { Header } from './components/layout/Header';
 import { Footer } from './components/layout/Footer';
 import './App.css';
-import { ToastContainer } from 'react-toastify';
+import { ToastContainer, toast } from 'react-toastify';
 
 const AppContent = () => {
   const location = useLocation();
@@ -96,9 +96,26 @@ const AppContent = () => {
 };
 
 function App() {
+  const [isRTL, setIsRTL] = useState(document.documentElement.dir === 'rtl');
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsRTL(document.documentElement.dir === 'rtl');
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['dir']
+    });
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <Router>
-      <ToastContainer />
+      <ToastContainer
+        position={isRTL ? toast.POSITION.TOP_LEFT : toast.POSITION.TOP_RIGHT}
+        rtl={isRTL}
+        toastClassName="custom-toast"
+      />
       <AppContent />
     </Router>
   );


### PR DESCRIPTION
## Summary
- make toast notifications follow page direction
- customize Toastify appearance

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d531532c83328ec418a1ed68d309