### PR TITLE
Fix duplicate key warning in markers

### DIFF
--- a/src/components/map/GeoJsonOverlay.jsx
+++ b/src/components/map/GeoJsonOverlay.jsx
@@ -97,7 +97,8 @@ const GeoJsonOverlay = ({ selectedCategory }) => {
         const hasFilter = !!selectedCategory;
         const iconSize = hasFilter ? (highlight ? 40 : 25) : 35;
         const iconOpacity = hasFilter ? (highlight ? 1 : 0.4) : 1;
-        const key = feature.properties?.uniqueId || idx;
+        const rawId = feature.properties?.uniqueId;
+        const key = rawId ? `${rawId}-${idx}` : idx;
         return (
           <Marker key={key} longitude={lng} latitude={lat} anchor="center">
             {getCompositeIcon(group, nodeFunction, iconSize, iconOpacity)}

--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -251,7 +251,8 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
         const hasFilter = !!selectedCategory;
         const iconSize = hasFilter ? (highlight ? 40 : 25) : 35;
         const iconOpacity = hasFilter ? (highlight ? 1 : 0.4) : 1;
-        const key = feature.properties?.uniqueId || idx;
+        const rawId = feature.properties?.uniqueId;
+        const key = rawId ? `${rawId}-${idx}` : idx;
         return (
           <Marker key={key} longitude={lng} latitude={lat} anchor="center">
             <div style={{ position: 'relative' }}>


### PR DESCRIPTION
## Summary
- ensure markers have unique keys by appending index when `uniqueId` repeats

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867d860450c8332be4a6fb304150357