### PR TITLE
Enable alternative route selection

### DIFF
--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -30,7 +30,13 @@ const RoutingPage = () => {
   const [was3DViewBeforeRouteView, setWas3DViewBeforeRouteView] = useState(false);
   const [is3DView, setIs3DView] = useState(false);
   const navigate = useNavigate();
-  const { routeSteps, routeGeo, alternativeRoutes } = useRouteStore();
+  const {
+    routeSteps,
+    routeGeo,
+    alternativeRoutes,
+    setRouteGeo,
+    setRouteSteps
+  } = useRouteStore();
 
   // Calculate total time in minutes from all steps
   const calculateTotalTime = (steps) => {
@@ -315,6 +321,14 @@ const RoutingPage = () => {
 
   const handleReturnFromAlternativeRoutes = () => {
     setIs3DView(was3DViewBeforeRouteView); // Restore previous 3D state
+    setShowAlternativeRoutes(false);
+  };
+
+  const handleSelectAlternativeRoute = (route) => {
+    setRouteGeo(route.geo);
+    setRouteSteps(route.steps);
+    setCurrentStep(0);
+    setIsRoutingActive(false);
     setShowAlternativeRoutes(false);
   };
 
@@ -621,7 +635,11 @@ const RoutingPage = () => {
 
               <div className="alternative-routes-container">
                 {routeData.alternativeRoutes.map(route => (
-                  <div key={route.id} className="alternative-route-card">
+                  <div
+                    key={route.id}
+                    className="alternative-route-card"
+                    onClick={() => handleSelectAlternativeRoute(route)}
+                  >
                     <div className="route-title">
                       <span><FormattedMessage id="from" /> {route.from}</span>
                       <span ><FormattedMessage id="to" /> {route.to}</span>

--- a/src/styles/Routing.css
+++ b/src/styles/Routing.css
@@ -852,6 +852,7 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   display: flex;
   flex-direction: column;
+  cursor: pointer;
 }
 
 .route-title {


### PR DESCRIPTION
## Summary
- allow selecting alternative routes on the RNG page
- make alternative route cards clickable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867deae569883328a48331e77df9150