### PR TITLE
Show clickable alternative routes on map

### DIFF
--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -155,6 +155,7 @@ const RoutingPage = () => {
       return {
         id: ridx + 1,
         steps: altSteps,
+        geo: alt.geo,
         totalTime: formatTotalTime(minutes),
         totalDistance: `${distTot} ${intl.formatMessage({ id: 'meters' })}`,
         from: alt.from,
@@ -571,6 +572,8 @@ const RoutingPage = () => {
               isMapModalOpen={isMapModalOpen}
               is3DView={is3DView}
               routeGeo={routeGeo}
+              alternativeRoutes={routeData.alternativeRoutes}
+              onSelectAlternativeRoute={handleSelectAlternativeRoute}
             />
           </div>
         )}

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -693,7 +693,7 @@ export function analyzeRoute(origin, destination, geoData) {
 
   altCandidates.sort((a, b) => a.distance - b.distance);
 
-  const alternatives = altCandidates.slice(0, 3).map(route => {
+  const alternatives = altCandidates.slice(0, 2).map(route => {
     const via = route.steps
       .filter(st => st.type !== 'stepArriveDestination')
       .map(st => st.name || st.title)


### PR DESCRIPTION
## Summary
- draw alternative routes on the routing map
- allow choosing an alternative by clicking the path on the map
- include geo information with each route
- limit generated alternatives to two

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e0708a1c83328abbec8b2562270b