### PR TITLE
Ensure unique alternative routes and transparent lines

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -120,7 +120,7 @@ const RouteMap = ({
           <Layer
             id={`alt-route-line-${idx}`}
             type="line"
-            paint={{ 'line-color': '#888', 'line-width': 3, 'line-dasharray': [2, 2] }}
+            paint={{ 'line-color': '#888', 'line-width': 3, 'line-dasharray': [2, 2], 'line-opacity': 0.4 }}
           />
         </Source>
       ))}

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -687,6 +687,20 @@ export function analyzeRoute(origin, destination, geoData) {
       const altNodePath = dijkstraShortestPath(allNodes, s.index, e.index, sahnPolygons);
       if (altNodePath.length === 0 || altNodePath.length === 1) return;
       const route = buildRoute(altNodePath);
+
+      const isSame = (coords1, coords2) => {
+        if (coords1.length !== coords2.length) return false;
+        for (let i = 0; i < coords1.length; i++) {
+          if (Math.abs(coords1[i][0] - coords2[i][0]) > 1e-6 || Math.abs(coords1[i][1] - coords2[i][1]) > 1e-6) {
+            return false;
+          }
+        }
+        return true;
+      };
+
+      if (isSame(route.geo.geometry.coordinates, mainRoute.geo.geometry.coordinates)) return;
+      if (altCandidates.some(r => isSame(r.geo.geometry.coordinates, route.geo.geometry.coordinates))) return;
+
       altCandidates.push(route);
     });
   });


### PR DESCRIPTION
## Summary
- de-duplicate alternative routes in `analyzeRoute`
- prevent main route from being returned as an alternative
- render alternative routes semi-transparent so they appear lighter on the map

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e2536178833293908cdbb82cfad4