### PR TITLE
Implement alternative route selection

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -152,6 +152,16 @@ const FinalSearch = () => {
     setDestination(temp);
   };
 
+  const handleSelectAlternativeRoute = (route) => {
+    if (!route?.geo || !route?.steps) {
+      console.warn('Selected alternative route is missing geo or steps');
+      return;
+    }
+
+    storeSetRouteGeo(route.geo);
+    storeSetRouteSteps(route.steps);
+  };
+
   const getTransportIcon = () => {
     switch (selectedTransport) {
       case 'walking':
@@ -459,7 +469,11 @@ const FinalSearch = () => {
           </h2>
           <div className="other-routes-container">
             {alternativeSummaries.map(route => (
-              <div key={route.id} className="other-route-card">
+              <div
+                key={route.id}
+                className="other-route-card"
+                onClick={() => handleSelectAlternativeRoute(storedAlternativeRoutes[route.id - 1])}
+              >
                 <div className="route-title">
                   <span>
                     <FormattedMessage id="from" /> {route.from}


### PR DESCRIPTION
## Summary
- enable selecting alternative routes on the FinalSearch page
- clicking an alternative route now updates the displayed route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e7f5446c8332b191aa6f90827c12