### PR TITLE
Ensure routing page recomputes route from QR coordinates

### DIFF
--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -4,6 +4,9 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import RouteMap from '../components/map/RouteMap';
 import '../styles/Routing.css';
 import { useRouteStore } from '../store/routeStore';
+import { useLangStore } from '../store/langStore';
+import { buildGeoJsonPath } from '../utils/geojsonPath.js';
+import { analyzeRoute } from '../utils/routeAnalysis';
 
 const RoutingPage = () => {
   const intl = useIntl();
@@ -31,12 +34,58 @@ const RoutingPage = () => {
   const [is3DView, setIs3DView] = useState(false);
   const navigate = useNavigate();
   const {
+    origin,
+    destination,
     routeSteps,
     routeGeo,
     alternativeRoutes,
+    setOrigin,
+    setDestination,
     setRouteGeo,
-    setRouteSteps
+    setRouteSteps,
+    setAlternativeRoutes
   } = useRouteStore();
+  const language = useLangStore(state => state.language);
+
+  // If QR coordinates are provided and stored route does not match, rebuild the route
+  useEffect(() => {
+    if (!storedLat || !storedLng) return;
+    const lat = parseFloat(storedLat);
+    const lng = parseFloat(storedLng);
+    const originChanged =
+      !origin ||
+      origin.coordinates?.[0] !== lat ||
+      origin.coordinates?.[1] !== lng;
+
+    if (!routeSteps.length || originChanged) {
+      const newOrigin = {
+        name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
+        coordinates: [lat, lng]
+      };
+      const newDestination =
+        destination || {
+          name: intl.formatMessage({ id: 'destSahnEnqelabName' }),
+          coordinates: [36.2975, 59.6072]
+        };
+
+      const file = buildGeoJsonPath(language);
+      fetch(file)
+        .then((res) => res.json())
+        .then((geoData) => {
+          const { geo, steps, alternatives } = analyzeRoute(
+            newOrigin,
+            newDestination,
+            geoData
+          );
+          setOrigin(newOrigin);
+          setDestination(newDestination);
+          setRouteGeo(geo);
+          setRouteSteps(steps);
+          setAlternativeRoutes(alternatives);
+        })
+        .catch((err) => console.error('failed to build route from QR', err));
+    }
+  }, [storedLat, storedLng, origin, destination, routeSteps.length, language, intl, setOrigin, setDestination, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
 
   // Calculate total time in minutes from all steps
   const calculateTotalTime = (steps) => {
@@ -84,8 +133,9 @@ const RoutingPage = () => {
     return `${hours}:${minutes}`;
   };
 
-  // Load route data from JSON
+  // Load route data from JSON for initial display when no analyzed route exists
   useEffect(() => {
+    if (routeSteps.length) return;
     fetch('./data/routeData.json')
       .then(response => response.json())
       .then(data => {
@@ -101,7 +151,7 @@ const RoutingPage = () => {
         });
       })
       .catch(error => console.error('Error loading route data:', error));
-  }, []);
+  }, [routeSteps.length]);
 
   // Build route data from stored steps
   useEffect(() => {


### PR DESCRIPTION
## Summary
- recompute route when opening the navigation page with QR coordinates
- load default demo data only if no analyzed route exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e9b54550833283ce7ff893649aff