### PR TITLE
Improve alt route style and swapping

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -120,7 +120,13 @@ const RouteMap = ({
           <Layer
             id={`alt-route-line-${idx}`}
             type="line"
-            paint={{ 'line-color': '#888', 'line-width': 3, 'line-dasharray': [2, 2], 'line-opacity': 0.4 }}
+            paint={{
+              'line-color': '#757575',
+              'line-width': 4,
+              'line-dasharray': [4, 3],
+              'line-opacity': 0.6
+            }}
+            layout={{ 'line-cap': 'round', 'line-join': 'round' }}
           />
         </Source>
       ))}

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -22,6 +22,7 @@ const FinalSearch = () => {
     origin: storedOrigin,
     destination: storedDestination,
     routeGeo: storedRouteGeo,
+    routeSteps: storedRouteSteps,
     alternativeRoutes: storedAlternativeRoutes,
     setOrigin: storeSetOrigin,
     setDestination: storeSetDestination,
@@ -158,8 +159,19 @@ const FinalSearch = () => {
       return;
     }
 
+    const currentRoute = {
+      geo: storedRouteGeo,
+      steps: storedRouteSteps
+    };
+    const newAlternatives = storedAlternativeRoutes.filter(alt => alt !== route);
+
+    if (currentRoute.geo && currentRoute.steps) {
+      newAlternatives.push(currentRoute);
+    }
+
     storeSetRouteGeo(route.geo);
     storeSetRouteSteps(route.steps);
+    storeSetAlternativeRoutes(newAlternatives);
   };
 
   const getTransportIcon = () => {
@@ -311,7 +323,13 @@ const FinalSearch = () => {
                 <Layer
                   id={`alt-route-line-${idx}`}
                   type="line"
-                  paint={{ 'line-color': '#888', 'line-width': 3, 'line-dasharray': [2, 2], 'line-opacity': 0.4 }}
+                  paint={{
+                    'line-color': '#757575',
+                    'line-width': 4,
+                    'line-dasharray': [4, 3],
+                    'line-opacity': 0.6
+                  }}
+                  layout={{ 'line-cap': 'round', 'line-join': 'round' }}
                 />
               </Source>
             ))}

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -35,7 +35,8 @@ const RoutingPage = () => {
     routeGeo,
     alternativeRoutes,
     setRouteGeo,
-    setRouteSteps
+    setRouteSteps,
+    setAlternativeRoutes
   } = useRouteStore();
 
   // Calculate total time in minutes from all steps
@@ -331,8 +332,16 @@ const RoutingPage = () => {
       return;
     }
 
+    const currentRoute = { geo: routeGeo, steps: routeSteps };
+    const newAlternatives = alternativeRoutes.filter(alt => alt !== route);
+
+    if (currentRoute.geo && currentRoute.steps) {
+      newAlternatives.push(currentRoute);
+    }
+
     setRouteGeo(route.geo);
     setRouteSteps(route.steps);
+    setAlternativeRoutes(newAlternatives);
     setCurrentStep(0);
     setIsRoutingActive(false);
     setShowAlternativeRoutes(false);


### PR DESCRIPTION
## Summary
- update alt route layer styling in `RouteMap` and `FinalSearch`
- keep rounded line caps/join via `layout` to avoid MapLibre errors

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867eae7818c8332a57ab9822e03cf6a