### PR TITLE
Fix undefined via in alternative route display

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -511,7 +511,7 @@ const FinalSearch = () => {
                     <FormattedMessage id="to" /> {route.to}
                   </span>
                 </div>
-                <div className="route-via">{route.via.join(' – ')}</div>
+                <div className="route-via">{Array.isArray(route.via) ? route.via.join(' – ') : ''}</div>
                 <div className="route-stats">
                   <div className="route-stat">
                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-walk">

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -716,7 +716,7 @@ const RoutingPage = () => {
                     </div>
 
                     <div className="route-via">
-                      {route.via.join(" – ")}
+                      {Array.isArray(route.via) ? route.via.join(" – ") : ''}
                     </div>
 
                     <div className="route-stats">


### PR DESCRIPTION
## Summary
- handle missing `via` arrays when showing alternative routes

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867eeb20170833285d6bd28142c04a1