### PR TITLE
Remove third entry path search

### DIFF
--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -670,14 +670,12 @@ export function analyzeRoute(origin, destination, geoData) {
 
   const startEntries = [
     startEntry,
-    findUnobstructedEntry(origin.coordinates, 1),
-    findUnobstructedEntry(origin.coordinates, 2)
+    findUnobstructedEntry(origin.coordinates, 1)
   ].filter(Boolean);
 
   const endEntries = [
     endEntry,
-    findUnobstructedEntry(destination.coordinates, 1),
-    findUnobstructedEntry(destination.coordinates, 2)
+    findUnobstructedEntry(destination.coordinates, 1)
   ].filter(Boolean);
 
   const altCandidates = [];


### PR DESCRIPTION
## Summary
- remove unused 3rd entry search when generating alternative routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867f27e2a1883329938496bd656509c