### PR TITLE
Enhance routing styles

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -118,13 +118,18 @@ const RouteMap = ({
       {alternativeRoutes.map((alt, idx) => (
         <Source key={idx} id={`alt-route-${idx}`} type="geojson" data={alt.geo}>
           <Layer
+            id={`alt-route-border-${idx}`}
+            type="line"
+            paint={{ 'line-color': '#3498db', 'line-width': 6 }}
+            layout={{ 'line-cap': 'round', 'line-join': 'round' }}
+          />
+          <Layer
             id={`alt-route-line-${idx}`}
             type="line"
             paint={{
-              'line-color': '#757575',
+              'line-color': '#bbdefb',
               'line-width': 4,
-              'line-dasharray': [4, 3],
-              'line-opacity': 0.6
+              'line-dasharray': [4, 3]
             }}
             layout={{ 'line-cap': 'round', 'line-join': 'round' }}
           />

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -344,13 +344,18 @@ const FinalSearch = () => {
             storedAlternativeRoutes.map((alt, idx) => (
               <Source key={idx} id={`alt-route-${idx}`} type="geojson" data={alt.geo}>
                 <Layer
+                  id={`alt-route-border-${idx}`}
+                  type="line"
+                  paint={{ 'line-color': '#2196F3', 'line-width': 8 }}
+                  layout={{ 'line-cap': 'round', 'line-join': 'round' }}
+                />
+                <Layer
                   id={`alt-route-line-${idx}`}
                   type="line"
                   paint={{
-                    'line-color': '#757575',
-                    'line-width': 4,
-                    'line-dasharray': [4, 3],
-                    'line-opacity': 0.6
+                    'line-color': '#bbdefb',
+                    'line-width': 6,
+                    'line-dasharray': [4, 3]
                   }}
                   layout={{ 'line-cap': 'round', 'line-join': 'round' }}
 


### PR DESCRIPTION
## Summary
- style alternate routes in RouteMap with light blue lines and blue borders
- give FinalSearch page the same alternate route style

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6868ddf07830833292d77847b9e9ac66