### PR TITLE
Add transport mode selector

### DIFF
--- a/src/components/common/ModeSelector.jsx
+++ b/src/components/common/ModeSelector.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { useRouteStore } from '../../store/routeStore';
+import '../../styles/ModeSelector.css';
+
+const ModeSelector = ({ className = '' }) => {
+  const transportMode = useRouteStore(state => state.transportMode);
+  const setTransportMode = useRouteStore(state => state.setTransportMode);
+
+  return (
+    <div className={`mode-options ${className}`}>
+      <button
+        className={`transport-btn ${transportMode === 'walking' ? 'active' : ''}`}
+        onClick={() => setTransportMode('walking')}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={transportMode === 'walking' ? '#2196F3' : '#666'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M13 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+          <path d="M7 21l3 -4" />
+          <path d="M16 21l-2 -4l-3 -3l1 -6" />
+          <path d="M6 12l2 -3l4 -1l3 3l3 1" />
+        </svg>
+        <FormattedMessage id="transportWalk" />
+      </button>
+      <button
+        className={`transport-btn ${transportMode === 'electric-car' ? 'active' : ''}`}
+        onClick={() => setTransportMode('electric-car')}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill={transportMode === 'electric-car' ? '#2196F3' : '#666'}>
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M14 5a1 1 0 0 1 .694 .28l.087 .095l3.699 4.625h.52a3 3 0 0 1 2.995 2.824l.005 .176v4a1 1 0 0 1 -1 1h-1.171a3.001 3.001 0 0 1 -5.658 0h-4.342a3.001 3.001 0 0 1 -5.658 0h-1.171a1 1 0 0 1 -1 -1v-6l.007 -.117l.008 -.056l.017 -.078l.012 -.036l.014 -.05l2.014 -5.034a1 1 0 0 1 .928 -.629zm-7 11a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m10 0a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m-6 -9h-5.324l-1.2 3h6.524zm2.52 0h-.52v3h2.92z" />
+        </svg>
+        <FormattedMessage id="transportCar" />
+      </button>
+      <button
+        className={`transport-btn ${transportMode === 'wheelchair' ? 'active' : ''}`}
+        onClick={() => setTransportMode('wheelchair')}
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={transportMode === 'wheelchair' ? '#2196F3' : '#666'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M11 5m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+          <path d="M11 7l0 8l4 0l4 5" />
+          <path d="M11 11l5 0" />
+          <path d="M7 11.5a5 5 0 1 0 6 7.5" />
+        </svg>
+        <FormattedMessage id="transportWheelchair" />
+      </button>
+    </div>
+  );
+};
+
+export default ModeSelector;

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -8,6 +8,7 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import osmStyle from '../services/osmStyle';
 import '../styles/FinalSearch.css';
+import ModeSelector from '../components/common/ModeSelector';
 import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
@@ -58,7 +59,7 @@ const FinalSearch = () => {
   useEffect(() => {
     storeSetDestination(destination);
   }, [destination, storeSetDestination]);
-  const [selectedTransport, setSelectedTransport] = useState('walking');
+  const { transportMode } = useRouteStore();
   const [selectedGender, setSelectedGender] = useState('male');
   const [routeInfo, setRouteInfo] = useState({ time: '9', distance: '75' });
   const [menuOpen, setMenuOpen] = useState(false);
@@ -70,14 +71,14 @@ const FinalSearch = () => {
   }, []);
 
   React.useEffect(() => {
-    if (selectedTransport === 'walking') {
+    if (transportMode === 'walking') {
       setRouteInfo({ time: '9', distance: '75' });
-    } else if (selectedTransport === 'electric-car') {
+    } else if (transportMode === 'electric-car') {
       setRouteInfo({ time: '5', distance: '120' });
-    } else if (selectedTransport === 'wheelchair') {
+    } else if (transportMode === 'wheelchair') {
       setRouteInfo({ time: '12', distance: '65' });
     }
-  }, [selectedTransport]);
+  }, [transportMode]);
 
   // Fallback to current GPS coordinates if origin coords not provided and no QR data
   useEffect(() => {
@@ -114,7 +115,7 @@ const FinalSearch = () => {
 
   useEffect(() => {
     if (!geoData) return;
-    const { geo, steps, alternatives } = analyzeRoute(origin, destination, geoData);
+    const { geo, steps, alternatives } = analyzeRoute(origin, destination, geoData, transportMode);
     // log analyzed route and alternatives for debugging
     console.log('analyzeRoute result:', {
       geo,
@@ -124,7 +125,7 @@ const FinalSearch = () => {
     storeSetRouteGeo(geo);
     storeSetRouteSteps(steps);
     storeSetAlternativeRoutes(alternatives);
-  }, [geoData, origin, destination, storeSetRouteGeo, storeSetRouteSteps, storeSetAlternativeRoutes]);
+  }, [geoData, origin, destination, transportMode, storeSetRouteGeo, storeSetRouteSteps, storeSetAlternativeRoutes]);
 
   const alternativeSummaries = React.useMemo(() => {
     if (!storedAlternativeRoutes) return [];
@@ -181,7 +182,7 @@ const FinalSearch = () => {
   };
 
   const getTransportIcon = () => {
-    switch (selectedTransport) {
+    switch (transportMode) {
       case 'walking':
         return (
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#181717" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -424,46 +425,7 @@ const FinalSearch = () => {
 
       {/* Options Section */}
       <div className="options-section">
-        <div className="options-row">
-          <button
-            className={`transport-btn ${selectedTransport === 'walking' ? 'active' : ''}`}
-            onClick={() => setSelectedTransport('walking')}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={selectedTransport === 'walking' ? '#2196F3' : '#666'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-              <path d="M13 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
-              <path d="M7 21l3 -4" />
-              <path d="M16 21l-2 -4l-3 -3l1 -6" />
-              <path d="M6 12l2 -3l4 -1l3 3l3 1" />
-            </svg>
-            <FormattedMessage id="transportWalk" />
-          </button>
-
-          <button
-            className={`transport-btn ${selectedTransport === 'electric-car' ? 'active' : ''}`}
-            onClick={() => setSelectedTransport('electric-car')}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill={selectedTransport === 'electric-car' ? '#2196F3' : '#666'}>
-              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-              <path d="M14 5a1 1 0 0 1 .694 .28l.087 .095l3.699 4.625h.52a3 3 0 0 1 2.995 2.824l.005 .176v4a1 1 0 0 1 -1 1h-1.171a3.001 3.001 0 0 1 -5.658 0h-4.342a3.001 3.001 0 0 1 -5.658 0h-1.171a1 1 0 0 1 -1 -1v-6l.007 -.117l.008 -.056l.017 -.078l.012 -.036l.014 -.05l2.014 -5.034a1 1 0 0 1 .928 -.629zm-7 11a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m10 0a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m-6 -9h-5.324l-1.2 3h6.524zm2.52 0h-.52v3h2.92z" />
-            </svg>
-            <FormattedMessage id="transportCar" />
-          </button>
-
-          <button
-            className={`transport-btn ${selectedTransport === 'wheelchair' ? 'active' : ''}`}
-            onClick={() => setSelectedTransport('wheelchair')}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke={selectedTransport === 'wheelchair' ? '#2196F3' : '#666'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-              <path d="M11 5m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
-              <path d="M11 7l0 8l4 0l4 5" />
-              <path d="M11 11l5 0" />
-              <path d="M7 11.5a5 5 0 1 0 6 7.5" />
-            </svg>
-            <FormattedMessage id="transportWheelchair" />
-          </button>
-        </div>
+        <ModeSelector />
 
         <div className="options-divider"></div>
 

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -4,6 +4,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import MapComponent from '../components/map/MapComponent';
 import { groups } from '../components/groupData';
 import { useRouteStore } from '../store/routeStore';
+import ModeSelector from '../components/common/ModeSelector';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
 import { useSearchStore } from '../store/searchStore';
@@ -338,6 +339,7 @@ const MapRoutingPage = () => {
 
       {/* Destination Input - Only shown when modal is NOT open and not selecting from map */}
       {!showDestinationModal && !showOriginModal && !isSelectingFromMap && (
+        <>
         <div className="map-destination-input-container" ref={modalRef}>
           <div className="location-icons-container">
             <div className="location-icon origin-icon">
@@ -409,6 +411,8 @@ const MapRoutingPage = () => {
             </div>
           </div>
         </div>
+        <ModeSelector />
+        </>
       )}
 
       {/* Destination Modal */}

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -7,6 +7,7 @@ import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
 import { analyzeRoute } from '../utils/routeAnalysis';
+import ModeSelector from '../components/common/ModeSelector';
 
 const RoutingPage = () => {
   const intl = useIntl();
@@ -39,6 +40,7 @@ const RoutingPage = () => {
     routeSteps,
     routeGeo,
     alternativeRoutes,
+    transportMode,
     setOrigin,
     setDestination,
     setRouteGeo,
@@ -86,6 +88,25 @@ const RoutingPage = () => {
         .catch((err) => console.error('failed to build route from QR', err));
     }
   }, [storedLat, storedLng, origin, destination, routeSteps.length, language, intl, setOrigin, setDestination, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
+
+  useEffect(() => {
+    if (!origin || !destination) return;
+    const file = buildGeoJsonPath(language);
+    fetch(file)
+      .then(res => res.json())
+      .then(geoData => {
+        const { geo, steps, alternatives } = analyzeRoute(
+          origin,
+          destination,
+          geoData,
+          transportMode
+        );
+        setRouteGeo(geo);
+        setRouteSteps(steps);
+        setAlternativeRoutes(alternatives);
+      })
+      .catch(err => console.error('failed to rebuild route', err));
+  }, [transportMode, origin, destination, language, intl, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
 
   // Calculate total time in minutes from all steps
   const calculateTotalTime = (steps) => {
@@ -821,9 +842,10 @@ const RoutingPage = () => {
                     </button>
                   </div>
                 </>
-              )}
+                )}
 
-              <div className="bottom-controls">
+                <ModeSelector />
+                <div className="bottom-controls">
                 <button
                   className={`start-routing-button ${isRoutingActive ? 'stop-routing' : ''}`}
                   onClick={toggleRouting}

--- a/src/store/routeStore.js
+++ b/src/store/routeStore.js
@@ -8,14 +8,16 @@ export const useRouteStore = create(
       destination: null,
       routeGeo: null,
       routeSteps: [],
+      transportMode: 'walking',
       alternativeRoutes: [],
       setOrigin: (origin) => set({ origin }),
       setDestination: (destination) => set({ destination }),
       setRouteGeo: (routeGeo) => set({ routeGeo }),
       setRouteSteps: (routeSteps) => set({ routeSteps }),
+      setTransportMode: (transportMode) => set({ transportMode }),
       setAlternativeRoutes: (alternativeRoutes) => set({ alternativeRoutes }),
       clearRoute: () =>
-        set({ origin: null, destination: null, routeGeo: null, routeSteps: [], alternativeRoutes: [] })
+        set({ origin: null, destination: null, routeGeo: null, routeSteps: [], alternativeRoutes: [], transportMode: 'walking' })
     }),
     {
       name: 'route-storage',

--- a/src/styles/ModeSelector.css
+++ b/src/styles/ModeSelector.css
@@ -1,0 +1,39 @@
+.mode-options {
+  display: flex;
+  gap: 10px;
+}
+
+.mode-options .transport-btn {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #edecec;
+  border-radius: 8px;
+  background-color: #e0e0e06e;
+  font-size: 0.9rem;
+  text-align: center;
+  transition: all 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  font-family: 'Vazir', Tahoma, sans-serif;
+  font-weight: 500;
+}
+
+.mode-options .transport-btn.active {
+  background-color: white;
+  border-color: #2196F3;
+  color: #2196F3;
+}
+
+.mode-options .transport-btn svg {
+  width: 24px;
+  height: 24px;
+}
+
+:root:lang(en) .mode-options .transport-btn {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}


### PR DESCRIPTION
## Summary
- store selected transportation mode in the route store
- add reusable `ModeSelector` component with walking, van and wheelchair buttons
- show the selector on map routing and navigation pages and in final search
- recompute routes whenever the mode changes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868f06eb8b88332bb1c14484dc00ea9