### PR TITLE
Show services for each route step

### DIFF
--- a/src/pages/RouteOverview.jsx
+++ b/src/pages/RouteOverview.jsx
@@ -32,7 +32,8 @@ const RouteOverview = () => {
         return {
           id: idx + 1,
           coordinates: [routeCoordinates[idx], c],
-          instruction
+          instruction,
+          services: step?.services || {}
         };
       }),
     [routeCoordinates, routeSteps, intl]
@@ -116,6 +117,35 @@ const RouteOverview = () => {
     }
   };
 
+  const renderServiceIcons = (services = {}) => (
+    <div className="step-services">
+      {services.wheelchair && (
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-wheelchair">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M11 5m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+          <path d="M11 7l0 8l4 0l4 5" />
+          <path d="M11 11l5 0" />
+          <path d="M7 11.5a5 5 0 1 0 6 7.5" />
+        </svg>
+      )}
+      {services.electricVan && (
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-car">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M14 5a1 1 0 0 1 .694 .28l.087 .095l3.699 4.625h.52a3 3 0 0 1 2.995 2.824l.005 .176v4a1 1 0 0 1 -1 1h-1.171a3.001 3.001 0 0 1 -5.658 0h-4.342a3.001 3.001 0 0 1 -5.658 0h-1.171a1 1 0 0 1 -1 -1v-6l.007 -.117l.008 -.056l.017 -.078l.012 -.036l.014 -.05l2.014 -5.034a1 1 0 0 1 .928 -.629zm-7 11a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m10 0a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m-6 -9h-5.324l-1.2 3h6.524zm2.52 0h-.52v3h2.92z" />
+        </svg>
+      )}
+      {services.walking && (
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-walk">
+          <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+          <path d="M13 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+          <path d="M7 21l3 -4" />
+          <path d="M16 21l-2 -4l-3 -3l1 -6" />
+          <path d="M6 12l2 -3l4 -1l3 3l3 1" />
+        </svg>
+      )}
+    </div>
+  );
+
   return (
     <div className="route-overview-container fade-in">
       <div className="header-container">
@@ -186,11 +216,12 @@ const RouteOverview = () => {
         </div>
 
         <div className="route-instruction-container">
-          <div className="route-instruction">
-            <p className="instruction-text">
-              {routeData[currentSlide]?.instruction}
-            </p>
-          </div>
+        <div className="route-instruction">
+          <p className="instruction-text">
+            {routeData[currentSlide]?.instruction}
+          </p>
+          {renderServiceIcons(routeData[currentSlide]?.services)}
+        </div>
 
           <div className="carousel-controls">
             <button

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -174,7 +174,8 @@ const RoutingPage = () => {
         instruction,
         distance: `${Math.round(distance)} ${intl.formatMessage({ id: 'meters' })}`,
         time: `${Math.max(1, Math.round(distance / 60))} ${intl.formatMessage({ id: 'minutesUnit' })}`,
-        coordinates: s.coordinates
+        coordinates: s.coordinates,
+        services: s.services || {}
       };
     });
     const totalMinutes = calculateTotalTime(steps);
@@ -618,6 +619,34 @@ const RoutingPage = () => {
               <span className="step-time">{step.time}</span>
             </div>
             <p className="step-instruction">{step.instruction}</p>
+            {step.services && (
+              <div className="step-services">
+                {step.services.wheelchair && (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-wheelchair">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M11 5m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+                    <path d="M11 7l0 8l4 0l4 5" />
+                    <path d="M11 11l5 0" />
+                    <path d="M7 11.5a5 5 0 1 0 6 7.5" />
+                  </svg>
+                )}
+                {step.services.electricVan && (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-car">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M14 5a1 1 0 0 1 .694 .28l.087 .095l3.699 4.625h.52a3 3 0 0 1 2.995 2.824l.005 .176v4a1 1 0 0 1 -1 1h-1.171a3.001 3.001 0 0 1 -5.658 0h-4.342a3.001 3.001 0 0 1 -5.658 0h-1.171a1 1 0 0 1 -1 -1v-6l.007 -.117l.008 -.056l.017 -.078l.012 -.036l.014 -.05l2.014 -5.034a1 1 0 0 1 .928 -.629zm-7 11a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m10 0a1 1 0 1 0 0 2a1 1 0 0 0 0 -2m-6 -9h-5.324l-1.2 3h6.524zm2.52 0h-.52v3h2.92z" />
+                  </svg>
+                )}
+                {step.services.walking && (
+                  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-walk">
+                    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                    <path d="M13 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+                    <path d="M7 21l3 -4" />
+                    <path d="M16 21l-2 -4l-3 -3l1 -6" />
+                    <path d="M6 12l2 -3l4 -1l3 3l3 1" />
+                  </svg>
+                )}
+              </div>
+            )}
             {index < routeData.steps.length - 1 && <hr className="step-divider" />}
           </div>
         ))}

--- a/src/styles/RouteOverview.css
+++ b/src/styles/RouteOverview.css
@@ -162,6 +162,17 @@
   height: 100px
 }
 
+.step-services {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.step-services svg {
+  width: 20px;
+  height: 20px;
+}
+
 /* Carousel Controls */
 .carousel-controls {
   display: flex;

--- a/src/styles/Routing.css
+++ b/src/styles/Routing.css
@@ -91,6 +91,17 @@
   margin-top: 20px;
 }
 
+.step-services {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.step-services svg {
+  width: 20px;
+  height: 20px;
+}
+
 .step-divider {
   border: none;
   margin: 5px 0;

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -634,13 +634,15 @@ export function analyzeRoute(origin, destination, geoData) {
         rSteps.push({
           coordinates: coord,
           type: 'stepPassDoor',
-          name: node[2].name || ''
+          name: node[2].name || '',
+          services: node[2].services || {}
         });
       } else if (node[2].nodeFunction === 'connection') {
         rSteps.push({
           coordinates: coord,
           type: 'stepPassConnection',
-          title: node[2].subGroup || node[2].name || ''
+          title: node[2].subGroup || node[2].name || '',
+          services: node[2].services || {}
         });
       }
     });


### PR DESCRIPTION
## Summary
- include services information with each routing step
- display service icons in the route overview
- show the same service icons in the guide list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868f073b57083328cbd63735fb8babc