### PR TITLE
Wrap verbose logs in development guard

### DIFF
--- a/src/components/map/MapView.jsx
+++ b/src/components/map/MapView.jsx
@@ -1,3 +1,4 @@
+import { debugLog } from '../../utils/debug.js';
 // src/components/map/MapView.jsx  
 import React, { useEffect, useState } from 'react';
 import { useIntl, FormattedMessage } from 'react-intl';
@@ -118,7 +119,7 @@ const MapView = ({
     const removeListener = advancedDeadReckoningService.addListener((data) => {
       // به‌روزرسانی وضعیت فعال بودن سرویس  
       setIsDrActive(data.isActive);
-      console.log('data.type: ', data.type);
+      debugLog('data.type: ', data.type);
       // if (data.type === 'stepDetected' || data.type === 'serviceStateChanged') {
       // به‌روزرسانی شمارنده گام  
       if (data.stepCount !== undefined && data.stepCount !== null) {
@@ -137,7 +138,7 @@ const MapView = ({
       if (data.geoPosition) {
         // بررسی اعتبار موقعیت  
         if (!isNaN(data.geoPosition.lat) && !isNaN(data.geoPosition.lng)) {
-          // console.log('Updating DR position:', data.geoPosition);
+          // debugLog('Updating DR position:', data.geoPosition);
           setDrPosition(data.geoPosition);
         }
       }
@@ -164,7 +165,7 @@ const MapView = ({
     if (kalmanState?.theta !== undefined) {
       const heading = kalmanState?.theta ?? 0;      // fallback = 0 rad
       // const degrees = ((kalmanState.theta * 180 / Math.PI) + 360) % 360;
-      // console.log(`Updating heading: ${headingInDegrees.toFixed(1)}° → ${degrees.toFixed(1)}°`);
+      // debugLog(`Updating heading: ${headingInDegrees.toFixed(1)}° → ${degrees.toFixed(1)}°`);
       setHeadingInDegrees(heading);
 
     }
@@ -172,7 +173,7 @@ const MapView = ({
 
   // Inside your component, add this useEffect to log state changes  
   useEffect(() => {
-    console.log('Heading state updated:', headingInDegrees.toFixed(2), '°');
+    debugLog('Heading state updated:', headingInDegrees.toFixed(2), '°');
   }, [headingInDegrees]);
   // ارسال داده‌های GPS به سرویس  
   useEffect(() => {

--- a/src/hooks/useIMUSensors.js
+++ b/src/hooks/useIMUSensors.js
@@ -1,3 +1,4 @@
+import { debugLog } from '../utils/debug.js';
 import { useState, useEffect } from 'react';
 import advancedDeadReckoningService from '../services/AdvancedDeadReckoningService';
 
@@ -18,8 +19,8 @@ const useIMUSensors = () => {
       const supported = hasMotion && hasOrientation;
       setIsSupported(supported);
 
-      console.log('Device motion support:', hasMotion);
-      console.log('Device orientation support:', hasOrientation);
+      debugLog('Device motion support:', hasMotion);
+      debugLog('Device orientation support:', hasOrientation);
 
       // در برخی مرورگرها مانند کروم دسکتاپ، نیازی به مجوز نیست  
       if (supported &&
@@ -32,7 +33,7 @@ const useIMUSensors = () => {
     };
 
     if (checkSupport()) {
-      console.log("IMU sensors are supported by this device");
+      debugLog("IMU sensors are supported by this device");
     } else {
       console.warn("IMU sensors are NOT supported by this device");
     }
@@ -44,7 +45,7 @@ const useIMUSensors = () => {
       return;
     }
 
-    console.log("Setting up sensor listeners");
+    debugLog("Setting up sensor listeners");
 
     // لیستنر شتاب‌سنج  
     const handleMotion = (event) => {
@@ -61,7 +62,7 @@ const useIMUSensors = () => {
           timestamp: event.timeStamp || Date.now(),
           includesGravity: false
         };
-        // console.log('[useIMUSensors] Accelerometer Raw Data:', accel);  
+        // debugLog('[useIMUSensors] Accelerometer Raw Data:', accel);  
 
         setAcceleration(accel);
 
@@ -126,11 +127,11 @@ const useIMUSensors = () => {
       window.addEventListener('deviceorientation', handleOrientation, true);
     }
 
-    console.log("Sensor listeners added");
+    debugLog("Sensor listeners added");
 
     // حذف لیستنرها در هنگام unmount  
     return () => {
-      console.log("Removing sensor listeners");
+      debugLog("Removing sensor listeners");
       window.removeEventListener('devicemotion', handleMotion);
       window.removeEventListener('deviceorientation', handleOrientation);
     };
@@ -148,18 +149,18 @@ const useIMUSensors = () => {
       if (typeof DeviceMotionEvent.requestPermission === 'function' &&
         typeof DeviceOrientationEvent.requestPermission === 'function') {
 
-        console.log('Requesting permissions for iOS...');
+        debugLog('Requesting permissions for iOS...');
 
         const motionPermission = await DeviceMotionEvent.requestPermission();
         const orientationPermission = await DeviceOrientationEvent.requestPermission();
 
         const granted = motionPermission === 'granted' && orientationPermission === 'granted';
         setHasPermission(granted);
-        console.log(`Permission ${granted ? 'granted' : 'denied'}`);
+        debugLog(`Permission ${granted ? 'granted' : 'denied'}`);
         return granted;
       } else {
         // برای سایر دستگاه‌ها، فرض می‌کنیم مجوز داریم  
-        console.log('No permission request needed for this device');
+        debugLog('No permission request needed for this device');
         setHasPermission(true);
         return true;
       }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,4 @@
+import { debugLog } from './utils/debug.js';
 // main.jsx  
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -19,11 +20,11 @@ import { registerSW } from 'virtual:pwa-register';
 // Use the plugin's registration method instead of manual registration
 const updateSW = registerSW({
   onNeedRefresh() {
-    console.log('New content is available; please refresh.');
+    debugLog('New content is available; please refresh.');
     // You can show a UI prompt to refresh here
   },
   onOfflineReady() {
-    console.log('Content is cached for offline use.');
+    debugLog('Content is cached for offline use.');
     // You can show a "ready for offline use" message here
   }
 }); 

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -1,3 +1,4 @@
+import { debugLog } from '../utils/debug.js';
 // src/pages/FinalSearch.jsx
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -116,7 +117,7 @@ const FinalSearch = () => {
     if (!geoData) return;
     const { geo, steps, alternatives } = analyzeRoute(origin, destination, geoData);
     // log analyzed route and alternatives for debugging
-    console.log('analyzeRoute result:', {
+    debugLog('analyzeRoute result:', {
       geo,
       steps,
       alternatives

--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -1,3 +1,4 @@
+import { debugLog } from '../utils/debug.js';
 import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
@@ -201,7 +202,7 @@ const Location = () => {
 
   const handleSearchSubmit = (e) => {
     e.preventDefault();
-    console.log('Searching for:', searchQuery);
+    debugLog('Searching for:', searchQuery);
   };
 
   const handleSearchToggle = () => {
@@ -210,7 +211,7 @@ const Location = () => {
   };
 
   const handlePlaceClick = (placeTitle, groupValue) => {
-    console.log('Place clicked:', placeTitle);
+    debugLog('Place clicked:', placeTitle);
     if (!geoData) return;
     let feature = geoData.features.find(
       f =>

--- a/src/services/AdvancedDeadReckoningService.js
+++ b/src/services/AdvancedDeadReckoningService.js
@@ -1,3 +1,4 @@
+import { debugLog } from '../utils/debug.js';
 // src/services/AdvancedDeadReckoningService.js  
 import { KalmanFilter } from './KalmanFilter';
 import { LowPassFilter } from '../utils/LowPassFilter';
@@ -44,7 +45,7 @@ class AdvancedDeadReckoningService {
             }
         });
 
-        console.log('Gyroscope heading processor initialized');
+        debugLog('Gyroscope heading processor initialized');
 
 
         // تشخیص گام (Peak Detector)  
@@ -114,7 +115,7 @@ class AdvancedDeadReckoningService {
 
         if (this.isActive) {
             // استارت سرویس  
-            console.log('Starting Advanced Dead Reckoning Service');
+            debugLog('Starting Advanced Dead Reckoning Service');
 
             // ابتدا کالیبراسیون را فعال کنید  
             this.isCalibrating = true;
@@ -146,7 +147,7 @@ class AdvancedDeadReckoningService {
                 !isNaN(initialLatLng.lat) &&
                 !isNaN(initialLatLng.lng)) {
 
-                console.log('Setting initial reference position:', initialLatLng);
+                debugLog('Setting initial reference position:', initialLatLng);
 
                 this.referencePosition = {
                     lat: initialLatLng.lat,
@@ -197,7 +198,7 @@ class AdvancedDeadReckoningService {
             }
         } else {
             // توقف سرویس  
-            console.log('Stopping Advanced Dead Reckoning Service');
+            debugLog('Stopping Advanced Dead Reckoning Service');
 
             // اطلاع‌رسانی به لیستنرها  
             this._notify({
@@ -218,7 +219,7 @@ class AdvancedDeadReckoningService {
     reset() {
         if (!this.isActive) return;
 
-        console.log('Resetting Advanced Dead Reckoning Service');
+        debugLog('Resetting Advanced Dead Reckoning Service');
 
         // پاکسازی مسیر و داده‌ها  
         this.path = [];
@@ -374,12 +375,12 @@ class AdvancedDeadReckoningService {
         }
 
         // لاگ داده‌های ورودی (خام)  
-        console.log('Raw gyroscope data:', gyroscope);
+        debugLog('Raw gyroscope data:', gyroscope);
         this._logSensorData('gyroscope', gyroscope, timestamp);
 
         // فیلتر داده‌های ژیروسکوپ  
         const filteredGyro = this._filterGyroscopeData(gyroscope);
-        // console.log('Filtered gyroscope data:', filteredGyro);
+        // debugLog('Filtered gyroscope data:', filteredGyro);
 
         // پردازش داده‌های سنسور برای به‌روزرسانی موقعیت  
         this._processSensorData({
@@ -433,7 +434,7 @@ class AdvancedDeadReckoningService {
                 { heading_accuracy: 0.1 }
             );
             this._lastOrientationCorrection = timestamp;
-            console.log('Orientation correction applied:', heading * 180 / Math.PI);
+            debugLog('Orientation correction applied:', heading * 180 / Math.PI);
         }
 
         // پردازش داده‌های سنسور برای به‌روزرسانی موقعیت  
@@ -468,7 +469,7 @@ class AdvancedDeadReckoningService {
 
         // اگر موقعیت مرجع تنظیم نشده است، آن را تنظیم کنید  
         if (!this.referencePosition) {
-            console.log('Setting reference position from GPS:', position);
+            debugLog('Setting reference position from GPS:', position);
 
             this.referencePosition = {
                 lat: position.lat,
@@ -549,7 +550,7 @@ class AdvancedDeadReckoningService {
             this.currentPosition.y
         );
 
-        console.log('proceccGpsData  >> currentGeoPosition: ' + currentGeoPosition)
+        debugLog('proceccGpsData  >> currentGeoPosition: ' + currentGeoPosition)
 
         // افزودن به مسیر اگر فاصله کافی از آخرین نقطه دارد  
         if (this.path.length === 0 || this._calculateDistance(
@@ -650,7 +651,7 @@ class AdvancedDeadReckoningService {
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
 
-        console.log('Log exported:', log);
+        debugLog('Log exported:', log);
         return log;
     }
 
@@ -815,7 +816,7 @@ class AdvancedDeadReckoningService {
         const gammaRad = (gammaDeg * Math.PI) / 180;
 
         // اضافه کردن لاگ برای دیباگ  
-        // console.log('Gyroscope filtered:', {
+        // debugLog('Gyroscope filtered:', {
         //     alpha: alphaDeg,
         //     beta: betaDeg,
         //     gamma: gammaDeg,
@@ -917,7 +918,7 @@ class AdvancedDeadReckoningService {
         // Update step detection
         if (data.type === 'accelerometer' && data.stepDetected) {
             controlInputs.a_norm = 1; // Step detected
-            console.log('Step detected, updating position');
+            debugLog('Step detected, updating position');
         }
 
 
@@ -1034,7 +1035,7 @@ class AdvancedDeadReckoningService {
         // Initialize filter with new state  
         this.kalmanFilter.initialize(state);
 
-        console.log('Forced rotation to:', degrees, 'degrees');
+        debugLog('Forced rotation to:', degrees, 'degrees');
 
         // Notify listeners  
         this._notify({

--- a/src/services/KalmanFilter.js
+++ b/src/services/KalmanFilter.js
@@ -1,3 +1,4 @@
+import { debugLog } from '../utils/debug.js';
 /**  
  * پیاده‌سازی Extended Kalman Filter برای تخمین موقعیت با ترکیب سنسورها  
  */
@@ -65,7 +66,7 @@ export class KalmanFilter {
       this.P[i * this.stateSize + i] = i < 2 ? 50.0 : 1.0;
     }
 
-    console.log("Kalman filter initialized:", this.getState());
+    debugLog("Kalman filter initialized:", this.getState());
   }
 
   /**  
@@ -106,7 +107,7 @@ export class KalmanFilter {
     const omega = u.omega || 0;    // سرعت زاویه‌ای (رادیان بر ثانیه)  
 
     // لاگ برای دیباگ  
-    console.log('Kalman filter predict inputs:', { dt, a_norm, omega });
+    debugLog('Kalman filter predict inputs:', { dt, a_norm, omega });
 
     // قابلیت ردیابی: اطمینان از عدم وجود مقادیر NaN  
     if (isNaN(a_norm) || isNaN(omega)) {
@@ -136,7 +137,7 @@ export class KalmanFilter {
       angularVelocity = this.x[4] * this.timeDecay;
     } else {
       // **FIX: ADDED LOGGING FOR NON-ZERO OMEGA**  
-      console.log('Non-zero omega detected:', omega);
+      debugLog('Non-zero omega detected:', omega);
     }
 
     // به‌روزرسانی بردار وضعیت (x) با استفاده از مدل حرکت غیرهولونومیک  
@@ -158,7 +159,7 @@ export class KalmanFilter {
     this.x[2] = newTheta;
 
     // لاگ برای تشخیص تغییرات زاویه  
-    console.log('Theta update:',
+    debugLog('Theta update:',
       (oldTheta * 180 / Math.PI).toFixed(2), '° → ',
       (newTheta * 180 / Math.PI).toFixed(2), '°',
       'omega:', omega.toFixed(6),
@@ -168,7 +169,7 @@ export class KalmanFilter {
     this.x[3] = velocity;  // v  
     this.x[4] = angularVelocity;  // w  
 
-    console.log('Theta after update:', (this.x[2] * 180 / Math.PI).toFixed(2), '°');
+    debugLog('Theta after update:', (this.x[2] * 180 / Math.PI).toFixed(2), '°');
 
     // به‌روزرسانی ماتریس P با استفاده از ژاکوبین تقریبی مدل سیستم  
     // برای سادگی، فقط Q را به P اضافه می‌کنیم  

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -1,0 +1,5 @@
+export function debugLog(...args) {
+  if (process.env.NODE_ENV === 'development') {
+    console.log(...args);
+  }
+}

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -1,3 +1,4 @@
+import { debugLog } from './debug.js';
 
 
 function booleanPointInPolygon(point, polygon) {
@@ -231,7 +232,7 @@ function crossesEmptyPolygons(coord1, coord2, polygons, nodes) {
       const p3 = vertices[i];
       const p4 = vertices[i + 1];
       if (segmentsIntersect(p1, p2, p3, p4)) {
-        console.log(`Line blocked by empty polygon: ${polygon.properties?.subGroupValue}`);
+        debugLog(`Line blocked by empty polygon: ${polygon.properties?.subGroupValue}`);
         return true;
       }
     }
@@ -379,19 +380,19 @@ function findValidNeighbors(nodeIndex, nodes, sahnPolygons) {
 
 // Dijkstra's algorithm for finding shortest path
 function dijkstraShortestPath(nodes, startNodeIndex, endNodeIndex, sahnPolygons) {
-  console.log(`Starting Enhanced Dijkstra with Connection Priority from node ${startNodeIndex} to ${endNodeIndex}`);
-  console.log(`Start node: [${nodes[startNodeIndex][0]}, ${nodes[startNodeIndex][1]}] - ${nodes[startNodeIndex][2]?.name || nodes[startNodeIndex][2]?.nodeFunction}`);
-  console.log(`End node: [${nodes[endNodeIndex][0]}, ${nodes[endNodeIndex][1]}] - ${nodes[endNodeIndex][2]?.name || nodes[endNodeIndex][2]?.nodeFunction}`);
+  debugLog(`Starting Enhanced Dijkstra with Connection Priority from node ${startNodeIndex} to ${endNodeIndex}`);
+  debugLog(`Start node: [${nodes[startNodeIndex][0]}, ${nodes[startNodeIndex][1]}] - ${nodes[startNodeIndex][2]?.name || nodes[startNodeIndex][2]?.nodeFunction}`);
+  debugLog(`End node: [${nodes[endNodeIndex][0]}, ${nodes[endNodeIndex][1]}] - ${nodes[endNodeIndex][2]?.name || nodes[endNodeIndex][2]?.nodeFunction}`);
   
   // Debug: Check start node connections
   const startCoord = [nodes[startNodeIndex][0], nodes[startNodeIndex][1]];
   const startPolygon = getPolygonContaining(startCoord, sahnPolygons);
   const startArea = startPolygon ? startPolygon.properties?.subGroupValue : 'outside';
   const startType = nodes[startNodeIndex][2]?.nodeFunction;
-  console.log(`Start node: area=${startArea}, type=${startType}`);
+  debugLog(`Start node: area=${startArea}, type=${startType}`);
   
   const startNeighbors = findValidNeighbors(startNodeIndex, nodes, sahnPolygons);
-  console.log(`Start node has ${startNeighbors.length} neighbors with connection priority:`);
+  debugLog(`Start node has ${startNeighbors.length} neighbors with connection priority:`);
   
   // Sort neighbors by priority (connection nodes first)
   const sortedNeighbors = startNeighbors.sort((a, b) => {
@@ -408,7 +409,7 @@ function dijkstraShortestPath(nodes, startNodeIndex, endNodeIndex, sahnPolygons)
     const neighborPolygon = getPolygonContaining(neighborCoord, sahnPolygons);
     const neighborArea = neighborPolygon ? neighborPolygon.properties?.subGroupValue : 'outside';
     const neighborType = nodes[n.index][2]?.nodeFunction;
-    console.log(`  -> Node ${n.index} (${nodes[n.index][2]?.name || 'unnamed'}) area=${neighborArea}, type=${neighborType}, weight=${n.weight.toFixed(6)}, reason=${n.reason}`);
+    debugLog(`  -> Node ${n.index} (${nodes[n.index][2]?.name || 'unnamed'}) area=${neighborArea}, type=${neighborType}, weight=${n.weight.toFixed(6)}, reason=${n.reason}`);
   });
   
   // Continue with standard Dijkstra
@@ -441,12 +442,12 @@ function dijkstraShortestPath(nodes, startNodeIndex, endNodeIndex, sahnPolygons)
     }
 
     if (currentIndex === null || minDist === Infinity) {
-      console.log(`Dijkstra stopped: no more reachable nodes (iteration ${iterations})`);
+      debugLog(`Dijkstra stopped: no more reachable nodes (iteration ${iterations})`);
       break;
     }
 
     if (currentIndex === endNodeIndex) {
-      console.log(`Dijkstra reached destination in ${iterations} iterations`);
+      debugLog(`Dijkstra reached destination in ${iterations} iterations`);
       break;
     }
 
@@ -463,20 +464,20 @@ function dijkstraShortestPath(nodes, startNodeIndex, endNodeIndex, sahnPolygons)
         previous[neighbor.index] = currentIndex;
         
         if (neighbor.index === endNodeIndex) {
-          console.log(`Found path to destination! Distance: ${alt}, via ${neighbor.reason}`);
+          debugLog(`Found path to destination! Distance: ${alt}, via ${neighbor.reason}`);
         }
       }
     }
   }
 
-  console.log(`Final distance to destination: ${distances[endNodeIndex]}`);
+  debugLog(`Final distance to destination: ${distances[endNodeIndex]}`);
 
   // Reconstruct path
   const path = [];
   let currentIndex = endNodeIndex;
   
   if (distances[endNodeIndex] === Infinity) {
-    console.log('Destination is not reachable from start node');
+    debugLog('Destination is not reachable from start node');
     return [];
   }
   
@@ -485,14 +486,14 @@ function dijkstraShortestPath(nodes, startNodeIndex, endNodeIndex, sahnPolygons)
     currentIndex = previous[currentIndex];
   }
 
-  console.log(`Enhanced Dijkstra found path with ${path.length} nodes`);
+  debugLog(`Enhanced Dijkstra found path with ${path.length} nodes`);
   
   // Log path details
-  console.log('Path details:');
+  debugLog('Path details:');
   path.forEach((node, index) => {
     const nodeType = node[2]?.nodeFunction;
     const nodeName = node[2]?.name || 'unnamed';
-    console.log(`  ${index}: ${nodeName} (${nodeType})`);
+    debugLog(`  ${index}: ${nodeName} (${nodeType})`);
   });
   
   return path.length > 0 && path[0] === nodes[startNodeIndex] ? path : [];
@@ -508,7 +509,7 @@ function angleBetween(p1, p2, p3) {
 }
 
 export function analyzeRoute(origin, destination, geoData) {
-  console.log('analyzeRoute called with Connection Priority Logic');
+  debugLog('analyzeRoute called with Connection Priority Logic');
   
   if (!geoData) {
     return { path: [origin.coordinates, destination.coordinates], steps: [] };
@@ -524,7 +525,7 @@ export function analyzeRoute(origin, destination, geoData) {
     f => f.geometry.type === 'Polygon' && f.properties?.subGroupValue?.startsWith('sahn-')
   );
   
-  console.log(`Found ${doors.length} doors, ${connections.length} connections, ${sahnPolygons.length} sahns`);
+  debugLog(`Found ${doors.length} doors, ${connections.length} connections, ${sahnPolygons.length} sahns`);
 
   // Create a unified list of all navigation nodes
   const allNodes = [];
@@ -541,22 +542,22 @@ export function analyzeRoute(origin, destination, geoData) {
     allNodes.push([lat, lng, conn.properties, 0, conn]);
   });
   
-  console.log(`Total nodes available: ${allNodes.length}`);
+  debugLog(`Total nodes available: ${allNodes.length}`);
 
   // Analyze polygons and their nodes using turf.js
-  console.log('Polygon analysis with turf.js:');
+  debugLog('Polygon analysis with turf.js:');
   const emptyPolygons = [];
   sahnPolygons.forEach(poly => {
     const nodesInPoly = getNodesInPolygon(allNodes, poly);
-    console.log(`  ${poly.properties?.subGroupValue}: ${nodesInPoly.length} nodes`);
+    debugLog(`  ${poly.properties?.subGroupValue}: ${nodesInPoly.length} nodes`);
     if (nodesInPoly.length === 0) {
       emptyPolygons.push(poly);
     }
   });
   
-  console.log(`Found ${emptyPolygons.length} empty polygons:`);
+  debugLog(`Found ${emptyPolygons.length} empty polygons:`);
   emptyPolygons.forEach(poly => {
-    console.log(`  - ${poly.properties?.subGroupValue}`);
+    debugLog(`  - ${poly.properties?.subGroupValue}`);
   });
 
   // Find unobstructed entry points
@@ -579,7 +580,7 @@ export function analyzeRoute(origin, destination, geoData) {
     }
     
     validNodes.sort((a, b) => a.distance - b.distance);
-    console.log(`Found ${validNodes.length} unobstructed nodes from [${coord[0]}, ${coord[1]}]`);
+    debugLog(`Found ${validNodes.length} unobstructed nodes from [${coord[0]}, ${coord[1]}]`);
     
     return validNodes[nth] || null;
   }
@@ -588,11 +589,11 @@ export function analyzeRoute(origin, destination, geoData) {
   const startEntry = findUnobstructedEntry(origin.coordinates, 0);
   const endEntry = findUnobstructedEntry(destination.coordinates, 0);
   
-  console.log('Start entry:', startEntry ? `Node ${startEntry.index}` : 'None');
-  console.log('End entry:', endEntry ? `Node ${endEntry.index}` : 'None');
+  debugLog('Start entry:', startEntry ? `Node ${startEntry.index}` : 'None');
+  debugLog('End entry:', endEntry ? `Node ${endEntry.index}` : 'None');
 
   if (!startEntry || !endEntry) {
-    console.log('Could not find valid entry/exit points, returning direct path');
+    debugLog('Could not find valid entry/exit points, returning direct path');
     const geo = {
       type: 'Feature',
       geometry: { type: 'LineString', coordinates: [origin.coordinates, destination.coordinates].map(p => [p[1], p[0]]) }
@@ -609,7 +610,7 @@ export function analyzeRoute(origin, destination, geoData) {
   const nodePath = dijkstraShortestPath(allNodes, startEntry.index, endEntry.index, sahnPolygons);
   
   if (nodePath.length === 0 || nodePath.length === 1) {
-    console.log('No valid path found between entry points, returning direct path');
+    debugLog('No valid path found between entry points, returning direct path');
     const geo = {
       type: 'Feature',
       geometry: { type: 'LineString', coordinates: [origin.coordinates, destination.coordinates].map(p => [p[1], p[0]]) }
@@ -719,7 +720,7 @@ export function analyzeRoute(origin, destination, geoData) {
     };
   });
 
-  console.log(`Final path has ${mainRoute.path.length} points`);
+  debugLog(`Final path has ${mainRoute.path.length} points`);
 
   return { path: mainRoute.path, geo: mainRoute.geo, steps: mainRoute.steps, alternatives };
 }

--- a/tests/routeAnalysis.test.js
+++ b/tests/routeAnalysis.test.js
@@ -13,4 +13,6 @@ assert.strictEqual(path[0][0], origin.coordinates[0]);
 assert.strictEqual(path[path.length - 1][0], destination.coordinates[0]);
 assert.ok(path.length >= 3, 'path should include intermediate nodes');
 
-console.log('computeShortestPath test passed');
+if (process.env.NODE_ENV === 'development') {
+  console.log('computeShortestPath test passed');
+}


### PR DESCRIPTION
## Summary
- add `debugLog` helper that only logs in development
- wrap existing `console.log` calls with `debugLog`
- gate test log behind NODE_ENV check

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868f0835700833286dc419d1910b119