### PR TITLE
Handle route unavailability

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -170,6 +170,7 @@
   ,"pwaInstallPrompt": "للوصول السريع، ثبّت التطبيق على جهازك."
   ,"pwaInstallButton": "تثبيت"
   ,"mapNoRecentSearches": "لا توجد عمليات بحث حديثة"
+  ,"noRouteFound": "لم يتم العثور على مسار للحالة المحددة"
   ,"pwaCloseButton": "إغلاق"
   ,"stepMoveToDoor": "اتجه نحو {name}"
   ,"stepPassConnection": "عبر نقطة الاتصال {title}"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -170,6 +170,7 @@
   ,"pwaInstallPrompt": "For quick access, install the app on your device."
   ,"pwaInstallButton": "Install"
   ,"mapNoRecentSearches": "No recent searches"
+  ,"noRouteFound": "No route found for selected mode"
   ,"pwaCloseButton": "Close"
   ,"stepMoveToDoor": "Head toward {name}"
   ,"stepPassConnection": "Pass connection {title}"

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -170,6 +170,7 @@
   ,"pwaInstallPrompt": "برای دسترسی سریع، اپلیکیشن را روی دستگاه خود نصب کنید."
   ,"pwaInstallButton": "نصب"
   ,"mapNoRecentSearches": "جستجوی اخیری وجود ندارد"
+  ,"noRouteFound": "مسیر با حالت انتخابی یافت نشد"
   ,"pwaCloseButton": "بستن"
   ,"stepMoveToDoor": "حرکت به سمت درب {name}"
   ,"stepPassConnection": "عبور از نقطه اتصال {title}"

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -170,6 +170,7 @@
   ,"pwaInstallPrompt": "تیز رسائی کے لیے ایپ اپنے آلے پر انسٹال کریں۔"
   ,"pwaInstallButton": "انسٹال"
   ,"mapNoRecentSearches": "کوئی حالیہ تلاش نہیں"
+  ,"noRouteFound": "منتخب موڈ کے لیے کوئی راستہ نہیں ملا"
   ,"pwaCloseButton": "بند کریں"
   ,"stepMoveToDoor": "{name} کی طرف جائیں"
   ,"stepPassConnection": "کنکشن پوائنٹ {title} سے گزریں"

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -13,6 +13,7 @@ import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
 import { analyzeRoute } from '../utils/routeAnalysis';
+import { toast } from 'react-toastify';
 
 const FinalSearch = () => {
   const [isSwapping, setIsSwapping] = useState(false);
@@ -115,8 +116,15 @@ const FinalSearch = () => {
 
   useEffect(() => {
     if (!geoData) return;
-    const { geo, steps, alternatives } = analyzeRoute(origin, destination, geoData, transportMode);
-    // log analyzed route and alternatives for debugging
+    const result = analyzeRoute(origin, destination, geoData, transportMode);
+    if (!result) {
+      toast.error(intl.formatMessage({ id: 'noRouteFound' }));
+      storeSetRouteGeo(null);
+      storeSetRouteSteps([]);
+      storeSetAlternativeRoutes([]);
+      return;
+    }
+    const { geo, steps, alternatives } = result;
     console.log('analyzeRoute result:', {
       geo,
       steps,
@@ -125,7 +133,7 @@ const FinalSearch = () => {
     storeSetRouteGeo(geo);
     storeSetRouteSteps(steps);
     storeSetAlternativeRoutes(alternatives);
-  }, [geoData, origin, destination, transportMode, storeSetRouteGeo, storeSetRouteSteps, storeSetAlternativeRoutes]);
+  }, [geoData, origin, destination, transportMode, storeSetRouteGeo, storeSetRouteSteps, storeSetAlternativeRoutes, intl]);
 
   const alternativeSummaries = React.useMemo(() => {
     if (!storedAlternativeRoutes) return [];

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -7,6 +7,7 @@ import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
 import { analyzeRoute } from '../utils/routeAnalysis';
+import { toast } from 'react-toastify';
 import ModeSelector from '../components/common/ModeSelector';
 
 const RoutingPage = () => {
@@ -74,12 +75,20 @@ const RoutingPage = () => {
       fetch(file)
         .then((res) => res.json())
         .then((geoData) => {
-          const { geo, steps, alternatives } = analyzeRoute(
+          const result = analyzeRoute(
             newOrigin,
             newDestination,
             geoData,
             'walking'
           );
+          if (!result) {
+            toast.error(intl.formatMessage({ id: 'noRouteFound' }));
+            setRouteGeo(null);
+            setRouteSteps([]);
+            setAlternativeRoutes([]);
+            return;
+          }
+          const { geo, steps, alternatives } = result;
           setOrigin(newOrigin);
           setDestination(newDestination);
           setRouteGeo(geo);
@@ -96,12 +105,20 @@ const RoutingPage = () => {
     fetch(file)
       .then(res => res.json())
       .then(geoData => {
-        const { geo, steps, alternatives } = analyzeRoute(
+        const result = analyzeRoute(
           origin,
           destination,
           geoData,
           transportMode
         );
+        if (!result) {
+          toast.error(intl.formatMessage({ id: 'noRouteFound' }));
+          setRouteGeo(null);
+          setRouteSteps([]);
+          setAlternativeRoutes([]);
+          return;
+        }
+        const { geo, steps, alternatives } = result;
         setRouteGeo(geo);
         setRouteSteps(steps);
         setAlternativeRoutes(alternatives);

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -509,9 +509,9 @@ function angleBetween(p1, p2, p3) {
 
 export function analyzeRoute(origin, destination, geoData, transportMode = 'walking') {
   console.log('analyzeRoute called with Connection Priority Logic');
-  
+
   if (!geoData) {
-    return { path: [origin.coordinates, destination.coordinates], steps: [] };
+    return null;
   }
   
   const doors = geoData.features.filter(
@@ -598,34 +598,16 @@ export function analyzeRoute(origin, destination, geoData, transportMode = 'walk
   console.log('End entry:', endEntry ? `Node ${endEntry.index}` : 'None');
 
   if (!startEntry || !endEntry) {
-    console.log('Could not find valid entry/exit points, returning direct path');
-    const geo = {
-      type: 'Feature',
-      geometry: { type: 'LineString', coordinates: [origin.coordinates, destination.coordinates].map(p => [p[1], p[0]]) }
-    };
-    return { 
-      path: [origin.coordinates, destination.coordinates], 
-      steps: [{ coordinates: destination.coordinates, type: 'stepArriveDestination', name: destination.name || '' }],
-      geo,
-      alternatives: []
-    };
+    console.log('Could not find valid entry/exit points');
+    return null;
   }
 
   // Use connection-priority Dijkstra to find the shortest path between entry points
   const nodePath = dijkstraShortestPath(allNodes, startEntry.index, endEntry.index, sahnPolygons);
   
   if (nodePath.length === 0 || nodePath.length === 1) {
-    console.log('No valid path found between entry points, returning direct path');
-    const geo = {
-      type: 'Feature',
-      geometry: { type: 'LineString', coordinates: [origin.coordinates, destination.coordinates].map(p => [p[1], p[0]]) }
-    };
-    return { 
-      path: [origin.coordinates, destination.coordinates], 
-      steps: [{ coordinates: destination.coordinates, type: 'stepArriveDestination', name: destination.name || '' }],
-      geo,
-      alternatives: []
-    };
+    console.log('No valid path found between entry points');
+    return null;
   }
 
   function buildRoute(nodeList) {


### PR DESCRIPTION
## Summary
- add translations for new `noRouteFound` message
- return `null` when no route is found
- show a toast and clear stored route when path analysis fails

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6868f7c401f48332aad99fa9f3caebd0