### PR TITLE
Fix transport mode service mapping

### DIFF
--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -510,6 +510,21 @@ function angleBetween(p1, p2, p3) {
 export function analyzeRoute(origin, destination, geoData, transportMode = 'walking') {
   console.log('analyzeRoute called with Connection Priority Logic');
 
+  const serviceKeyMap = {
+    'electric-car': ['electric-car', 'electricCar', 'electricVan']
+  };
+
+  const serviceAllowed = (services, mode) => {
+    if (!services) return true;
+    const keys = serviceKeyMap[mode] || [mode];
+    for (const key of keys) {
+      if (Object.prototype.hasOwnProperty.call(services, key)) {
+        return services[key] !== false;
+      }
+    }
+    return true;
+  };
+
   if (!geoData) {
     return null;
   }
@@ -518,13 +533,13 @@ export function analyzeRoute(origin, destination, geoData, transportMode = 'walk
     f =>
       f.geometry.type === 'Point' &&
       f.properties?.nodeFunction === 'door' &&
-      f.properties?.services?.[transportMode] !== false
+      serviceAllowed(f.properties?.services, transportMode)
   );
   const connections = geoData.features.filter(
     f =>
       f.geometry.type === 'Point' &&
       f.properties?.nodeFunction === 'connection' &&
-      f.properties?.services?.[transportMode] !== false
+      serviceAllowed(f.properties?.services, transportMode)
   );
   const sahnPolygons = geoData.features.filter(
     f => f.geometry.type === 'Polygon' && f.properties?.subGroupValue?.startsWith('sahn-')

--- a/tests/routeAnalysis.test.js
+++ b/tests/routeAnalysis.test.js
@@ -43,4 +43,21 @@ assert.strictEqual(
   'wheelchair alternatives should not include connection'
 );
 
+// Same dataset but using "electricVan" service key
+const geoVan = {
+  type: 'FeatureCollection',
+  features: [
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: { nodeFunction: 'door', name: 'A', services: { walking: true, electricVan: true, wheelchair: true } } },
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [0.0001, 0] }, properties: { nodeFunction: 'connection', name: 'X', services: { walking: false, electricVan: true, wheelchair: false } } },
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [0.0002, 0] }, properties: { nodeFunction: 'door', name: 'D', services: { walking: true, electricVan: true, wheelchair: true } } }
+  ]
+};
+
+const carVan = analyzeRoute(origin2, destination2, geoVan, 'electric-car');
+
+assert.ok(
+  containsConnection(carVan),
+  'electric-car with electricVan key should include connection'
+);
+
 console.log('analyzeRoute service filtering tests passed');


### PR DESCRIPTION
## Summary
- support alternative service keys like `electricVan`
- update tests to cover electricVan service key

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6868f9910ce48332b38ebe036ad5556f