### PR TITLE
Add gender-aware routing filtering

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -20,17 +20,19 @@ const FinalSearch = () => {
   const [isSwapButton, setSwapButton] = useState(true);
   const navigate = useNavigate();
   const intl = useIntl();
-  const { 
+  const {
     origin: storedOrigin,
     destination: storedDestination,
     routeGeo: storedRouteGeo,
     routeSteps: storedRouteSteps,
     alternativeRoutes: storedAlternativeRoutes,
+    gender: storedGender,
     setOrigin: storeSetOrigin,
     setDestination: storeSetDestination,
     setRouteGeo: storeSetRouteGeo,
     setRouteSteps: storeSetRouteSteps,
-    setAlternativeRoutes: storeSetAlternativeRoutes
+    setAlternativeRoutes: storeSetAlternativeRoutes,
+    setGender: storeSetGender
   } = useRouteStore();
   const language = useLangStore((state) => state.language);
   const qrLat = sessionStorage.getItem('qrLat');
@@ -61,10 +63,14 @@ const FinalSearch = () => {
     storeSetDestination(destination);
   }, [destination, storeSetDestination]);
   const { transportMode } = useRouteStore();
-  const [selectedGender, setSelectedGender] = useState('male');
+  const [selectedGender, setSelectedGender] = useState(storedGender || 'male');
   const [routeInfo, setRouteInfo] = useState({ time: '9', distance: '75' });
   const [menuOpen, setMenuOpen] = useState(false);
   const [geoData, setGeoData] = useState(null);
+
+  useEffect(() => {
+    storeSetGender(selectedGender);
+  }, [selectedGender, storeSetGender]);
 
   React.useEffect(() => {
     // Scroll to top when component mounts
@@ -116,7 +122,7 @@ const FinalSearch = () => {
 
   useEffect(() => {
     if (!geoData) return;
-    const result = analyzeRoute(origin, destination, geoData, transportMode);
+    const result = analyzeRoute(origin, destination, geoData, transportMode, selectedGender);
     if (!result) {
       toast.error(intl.formatMessage({ id: 'noRouteFound' }));
       storeSetRouteGeo(null);

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -42,6 +42,7 @@ const RoutingPage = () => {
     routeGeo,
     alternativeRoutes,
     transportMode,
+    gender,
     setOrigin,
     setDestination,
     setRouteGeo,
@@ -79,7 +80,8 @@ const RoutingPage = () => {
             newOrigin,
             newDestination,
             geoData,
-            'walking'
+            'walking',
+            gender
           );
           if (!result) {
             toast.error(intl.formatMessage({ id: 'noRouteFound' }));
@@ -97,7 +99,7 @@ const RoutingPage = () => {
         })
         .catch((err) => console.error('failed to build route from QR', err));
     }
-  }, [storedLat, storedLng, origin, destination, routeSteps.length, language, intl, setOrigin, setDestination, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
+  }, [storedLat, storedLng, origin, destination, routeSteps.length, language, intl, gender, setOrigin, setDestination, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
 
   useEffect(() => {
     if (!origin || !destination) return;
@@ -109,7 +111,8 @@ const RoutingPage = () => {
           origin,
           destination,
           geoData,
-          transportMode
+          transportMode,
+          gender
         );
         if (!result) {
           toast.error(intl.formatMessage({ id: 'noRouteFound' }));
@@ -124,7 +127,7 @@ const RoutingPage = () => {
         setAlternativeRoutes(alternatives);
       })
       .catch(err => console.error('failed to rebuild route', err));
-  }, [transportMode, origin, destination, language, intl, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
+  }, [transportMode, gender, origin, destination, language, intl, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
 
   // Calculate total time in minutes from all steps
   const calculateTotalTime = (steps) => {

--- a/src/store/routeStore.js
+++ b/src/store/routeStore.js
@@ -9,15 +9,17 @@ export const useRouteStore = create(
       routeGeo: null,
       routeSteps: [],
       transportMode: 'walking',
+      gender: 'male',
       alternativeRoutes: [],
       setOrigin: (origin) => set({ origin }),
       setDestination: (destination) => set({ destination }),
       setRouteGeo: (routeGeo) => set({ routeGeo }),
       setRouteSteps: (routeSteps) => set({ routeSteps }),
       setTransportMode: (transportMode) => set({ transportMode }),
+      setGender: (gender) => set({ gender }),
       setAlternativeRoutes: (alternativeRoutes) => set({ alternativeRoutes }),
       clearRoute: () =>
-        set({ origin: null, destination: null, routeGeo: null, routeSteps: [], alternativeRoutes: [], transportMode: 'walking' })
+        set({ origin: null, destination: null, routeGeo: null, routeSteps: [], alternativeRoutes: [], transportMode: 'walking', gender: 'male' })
     }),
     {
       name: 'route-storage',

--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -507,7 +507,7 @@ function angleBetween(p1, p2, p3) {
   return Math.round(deg);
 }
 
-export function analyzeRoute(origin, destination, geoData, transportMode = 'walking') {
+export function analyzeRoute(origin, destination, geoData, transportMode = 'walking', gender = 'male') {
   console.log('analyzeRoute called with Connection Priority Logic');
 
   const serviceKeyMap = {
@@ -525,6 +525,12 @@ export function analyzeRoute(origin, destination, geoData, transportMode = 'walk
     return true;
   };
 
+  const genderAllowed = (nodeGender, selected) => {
+    if (!nodeGender || nodeGender === 'family') return true;
+    if (selected === 'family') return true;
+    return nodeGender === selected;
+  };
+
   if (!geoData) {
     return null;
   }
@@ -533,13 +539,15 @@ export function analyzeRoute(origin, destination, geoData, transportMode = 'walk
     f =>
       f.geometry.type === 'Point' &&
       f.properties?.nodeFunction === 'door' &&
-      serviceAllowed(f.properties?.services, transportMode)
+      serviceAllowed(f.properties?.services, transportMode) &&
+      genderAllowed(f.properties?.gender, gender)
   );
   const connections = geoData.features.filter(
     f =>
       f.geometry.type === 'Point' &&
       f.properties?.nodeFunction === 'connection' &&
-      serviceAllowed(f.properties?.services, transportMode)
+      serviceAllowed(f.properties?.services, transportMode) &&
+      genderAllowed(f.properties?.gender, gender)
   );
   const sahnPolygons = geoData.features.filter(
     f => f.geometry.type === 'Polygon' && f.properties?.subGroupValue?.startsWith('sahn-')

--- a/tests/routeAnalysis.test.js
+++ b/tests/routeAnalysis.test.js
@@ -19,9 +19,9 @@ console.log('computeShortestPath test passed');
 const origin2 = { coordinates: [0, -0.00005] };
 const destination2 = { coordinates: [0, 0.00025] };
 
-const walking = analyzeRoute(origin2, destination2, geo, 'walking');
-const car = analyzeRoute(origin2, destination2, geo, 'electric-car');
-const wheelchair = analyzeRoute(origin2, destination2, geo, 'wheelchair');
+const walking = analyzeRoute(origin2, destination2, geo, 'walking', 'family');
+const car = analyzeRoute(origin2, destination2, geo, 'electric-car', 'family');
+const wheelchair = analyzeRoute(origin2, destination2, geo, 'wheelchair', 'family');
 
 const containsConnection = route =>
   route.alternatives.some(a =>
@@ -58,6 +58,15 @@ const carVan = analyzeRoute(origin2, destination2, geoVan, 'electric-car');
 assert.ok(
   containsConnection(carVan),
   'electric-car with electricVan key should include connection'
+);
+
+// Gender filtering test using sample geojson connection (male only)
+const female = analyzeRoute(origin2, destination2, geo, 'walking', 'female');
+
+assert.strictEqual(
+  containsConnection(female),
+  false,
+  'female routes should not include male-only connection'
 );
 
 console.log('analyzeRoute service filtering tests passed');

--- a/tests/sample.geojson
+++ b/tests/sample.geojson
@@ -2,7 +2,7 @@
   "type": "FeatureCollection",
   "features": [
     {"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{"nodeFunction":"door","name":"A","services":{"walking":true,"electric-car":true,"wheelchair":true}}},
-    {"type":"Feature","geometry":{"type":"Point","coordinates":[0.0001,0]},"properties":{"nodeFunction":"connection","name":"X","services":{"walking":false,"electric-car":true,"wheelchair":false}}},
+    {"type":"Feature","geometry":{"type":"Point","coordinates":[0.0001,0]},"properties":{"nodeFunction":"connection","name":"X","services":{"walking":false,"electric-car":true,"wheelchair":false},"gender":"male"}},
     {"type":"Feature","geometry":{"type":"Point","coordinates":[0.0002,0]},"properties":{"nodeFunction":"door","name":"D","services":{"walking":true,"electric-car":true,"wheelchair":true}}}
   ]
 }


### PR DESCRIPTION
## Summary
- support gender in route store
- filter map features by gender in analyzeRoute
- persist chosen gender in FinalSearch and Routing pages
- ensure gender restrictions handle in algorithm
- update unit tests for gender logic

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868ff1df278833285103b682ca05eb9