### PR TITLE
Add popup with time for alternative routes

### DIFF
--- a/src/styles/FinalSearch.css
+++ b/src/styles/FinalSearch.css
@@ -629,3 +629,8 @@
   gap: 8px;
   font-size: 1rem;
 }
+
+.time-popup {
+  font-size: 0.9rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- compute popup positions/time for alternative routes
- show popup markers for each alternative path

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68690476a03483329fa2cd263f26f265