### PR TITLE
Fix popup arrow visibility

### DIFF
--- a/src/styles/FinalSearch.css
+++ b/src/styles/FinalSearch.css
@@ -656,5 +656,5 @@
 
 .maplibregl-popup-tip,
 .mapboxgl-popup-tip {
-  display: none;
+  display: block;
 }


### PR DESCRIPTION
## Summary
- restore visibility for popup arrow tips

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686909084c1483329966340239f0705c