### PR TITLE
fix gps override with qr coordinates

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -102,9 +102,13 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
         coordinates: [c.lat, c.lng]
       });
       setViewState((v) => ({ ...v, latitude: c.lat, longitude: c.lng }));
-      return;
+      return; // Do not start GPS tracking when QR coords are present
     }
     const success = (pos) => {
+      // Ignore GPS updates if QR coordinates become available later
+      if (sessionStorage.getItem('qrLat') && sessionStorage.getItem('qrLng')) {
+        return;
+      }
       const c = { lat: pos.coords.latitude, lng: pos.coords.longitude };
       setUserCoords(c);
       setUserLocation({

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -300,6 +300,9 @@ const RoutingPage = () => {
         }
 
         const success = (position) => {
+          if (sessionStorage.getItem('qrLat') && sessionStorage.getItem('qrLng')) {
+            return;
+          }
           setUserLocation([position.coords.latitude, position.coords.longitude])
         }
 


### PR DESCRIPTION
## Summary
- ignore GPS updates if QR code coordinates are present
- prevent route page watcher from overwriting QR code location

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bcd39a1c88332861dadc8b04d7fbd