### PR TITLE
Update coordinate handling on startup

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -101,7 +101,7 @@ const MapComponent = ({ setUserLocation, selectedDestination, isSwapped, onMapCl
         name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
         coordinates: [c.lat, c.lng]
       });
-      setViewState((v) => ({ ...v, latitude: c.lat, longitude: c.lng }));
+      setViewState((v) => ({ ...v, latitude: c.lat, longitude: c.lng, zoom: 18 }));
       return; // Do not start GPS tracking when QR coords are present
     }
     const success = (pos) => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,14 +4,28 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import IntlProviderWrapper from './IntlProviderWrapper.jsx';
 import './index.css';
+import { useGPSStore } from './store/gpsStore.js';
 
-// Check URL parameters for QR code location and store in session
-const params = new URLSearchParams(window.location.search);
+// Check URL parameters for QR code location (works with ? before or after #)
+let search = window.location.search;
+if (!search && window.location.hash.includes('?')) {
+  search = window.location.hash.split('?')[1];
+  if (search) search = '?' + search;
+}
+
+const params = new URLSearchParams(search);
 const lat = params.get('lat');
 const lng = params.get('lng');
 if (lat && lng) {
   sessionStorage.setItem('qrLat', lat);
   sessionStorage.setItem('qrLng', lng);
+
+  // Also update the GPS store so components can use this location immediately
+  const updateCurrentLocation = useGPSStore.getState().updateCurrentLocation;
+  updateCurrentLocation({
+    coords: { lat: parseFloat(lat), lng: parseFloat(lng), accuracy: 0 },
+    timestamp: Date.now()
+  });
 }
 
 import { registerSW } from 'virtual:pwa-register';


### PR DESCRIPTION
## Summary
- parse `lat` and `lng` params from either the URL search part or the hash fragment
- update the GPS store with coordinates from the URL
- zoom closer when QR coordinates are used

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bcf6de4a88332a31c83ce93914534