### PR TITLE
Fix map address param parsing

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,10 @@ if (!search && window.location.hash.includes('?')) {
   search = window.location.hash.split('?')[1];
   if (search) search = '?' + search;
 }
+// Handle encoded ampersands from copied HTML links
+if (search && search.includes('&amp;')) {
+  search = search.replace(/&amp;/g, '&');
+}
 
 const params = new URLSearchParams(search);
 const lat = params.get('lat');


### PR DESCRIPTION
## Summary
- handle encoded ampersands when parsing URL search params

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bd1ecab108332a35400a787c78740