### PR TITLE
Fix missing intl ID in RouteOverview

### DIFF
--- a/src/pages/RouteOverview.jsx
+++ b/src/pages/RouteOverview.jsx
@@ -51,9 +51,14 @@ const RouteOverview = () => {
     () =>
       routeCoordinates.slice(1).map((c, idx) => {
         const step = routeSteps?.[idx];
-        const instruction = step
-          ? intl.formatMessage({ id: step.type }, { name: step.name, title: step.title, num: idx + 1 })
-          : intl.formatMessage({ id: 'stepNumber' }, { num: idx + 1 });
+        const instruction = step && step.type
+          ? intl.formatMessage(
+              { id: step.type },
+              { name: step.name, title: step.title, num: idx + 1 }
+            )
+          : step?.instruction
+            ? step.instruction
+            : intl.formatMessage({ id: 'stepNumber' }, { num: idx + 1 });
         return {
           id: idx + 1,
           coordinates: [routeCoordinates[idx], c],


### PR DESCRIPTION
## Summary
- handle steps without `type` in RouteOverview to avoid intl errors

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c3a7e1c1c8332b84ee58fdaec2351