### PR TITLE
Store route info in session

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -134,6 +134,9 @@ const FinalSearch = () => {
       storeSetRouteGeo(null);
       storeSetRouteSteps([]);
       storeSetAlternativeRoutes([]);
+      sessionStorage.removeItem('routeGeo');
+      sessionStorage.removeItem('routeSteps');
+      sessionStorage.removeItem('alternativeRoutes');
       return;
     }
     const { geo, steps, alternatives } = result;
@@ -145,6 +148,11 @@ const FinalSearch = () => {
     storeSetRouteGeo(geo);
     storeSetRouteSteps(steps);
     storeSetAlternativeRoutes(alternatives);
+    sessionStorage.setItem('routeGeo', JSON.stringify(geo));
+    sessionStorage.setItem('routeSteps', JSON.stringify(steps));
+    sessionStorage.setItem('alternativeRoutes', JSON.stringify(alternatives));
+    sessionStorage.setItem('origin', JSON.stringify(origin));
+    sessionStorage.setItem('destination', JSON.stringify(destination));
   }, [geoData, origin, destination, transportMode, selectedGender, storeSetRouteGeo, storeSetRouteSteps, storeSetAlternativeRoutes, intl]);
 
   const alternativeSummaries = React.useMemo(() => {

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -52,6 +52,21 @@ const RoutingPage = () => {
   } = useRouteStore();
   const language = useLangStore(state => state.language);
 
+  useEffect(() => {
+    const sessGeo = sessionStorage.getItem('routeGeo');
+    const sessSteps = sessionStorage.getItem('routeSteps');
+    const sessAlts = sessionStorage.getItem('alternativeRoutes');
+    const sessOrigin = sessionStorage.getItem('origin');
+    const sessDestination = sessionStorage.getItem('destination');
+    if (sessGeo && sessSteps) {
+      setRouteGeo(JSON.parse(sessGeo));
+      setRouteSteps(JSON.parse(sessSteps));
+      setAlternativeRoutes(sessAlts ? JSON.parse(sessAlts) : []);
+      if (sessOrigin) setOrigin(JSON.parse(sessOrigin));
+      if (sessDestination) setDestination(JSON.parse(sessDestination));
+    }
+  }, [setRouteGeo, setRouteSteps, setAlternativeRoutes, setOrigin, setDestination]);
+
   // If QR coordinates are provided and stored route does not match, rebuild the route
   useEffect(() => {
     if (!storedLat || !storedLng) return;
@@ -104,6 +119,7 @@ const RoutingPage = () => {
 
   useEffect(() => {
     if (!origin || !destination) return;
+    if (routeGeo && routeSteps.length) return;
     const file = buildGeoJsonPath(language);
     fetch(file)
       .then(res => res.json())
@@ -128,7 +144,7 @@ const RoutingPage = () => {
         setAlternativeRoutes(alternatives);
       })
       .catch(err => console.error('failed to rebuild route', err));
-  }, [transportMode, gender, origin, destination, language, intl, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
+  }, [transportMode, gender, origin, destination, language, intl, routeGeo, routeSteps.length, setRouteGeo, setRouteSteps, setAlternativeRoutes]);
 
   // Calculate total time in minutes from all steps
   const calculateTotalTime = (steps) => {


### PR DESCRIPTION
## Summary
- cache computed route data in FinalSearch page using session storage
- load cached route in Routing page to avoid recalculating
- skip route analysis when data is already present

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c3e67b39c8332ba46b473c413b2e9