### PR TITLE
Ensure route swap on map click

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -21,7 +21,10 @@ const RouteMap = ({
   const center = userLocation && userLocation.length === 2
     ? userLocation
     : [36.297, 59.606]; // Default to Imam Reza Shrine coordinates
-  const altLayerIds = alternativeRoutes.map((_, idx) => `alt-route-line-${idx}`);
+  const altLayerIds = alternativeRoutes.flatMap((_, idx) => [
+    `alt-route-line-${idx}`,
+    `alt-route-border-${idx}`
+  ]);
 
   // Handle map resize when modal opens/closes
   useEffect(() => {
@@ -92,8 +95,15 @@ const RouteMap = ({
       interactiveLayerIds={altLayerIds}
       onClick={(e) => {
         const feature = e.features && e.features[0];
-        if (feature && feature.layer && feature.layer.id.startsWith('alt-route-line-')) {
-          const idx = parseInt(feature.layer.id.replace('alt-route-line-', ''));
+        if (
+          feature &&
+          feature.layer &&
+          (feature.layer.id.startsWith('alt-route-line-') ||
+            feature.layer.id.startsWith('alt-route-border-'))
+        ) {
+          const idx = parseInt(
+            feature.layer.id.replace(/alt-route-(?:line|border)-/, '')
+          );
           if (!Number.isNaN(idx) && alternativeRoutes[idx] && onSelectAlternativeRoute) {
             onSelectAlternativeRoute(alternativeRoutes[idx]);
           }

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -176,7 +176,10 @@ const FinalSearch = () => {
 
   const altLayerIds = React.useMemo(
     () =>
-      (storedAlternativeRoutes || []).map((_, idx) => `alt-route-line-${idx}`),
+      (storedAlternativeRoutes || []).flatMap((_, idx) => [
+        `alt-route-line-${idx}`,
+        `alt-route-border-${idx}`
+      ]),
     [storedAlternativeRoutes]
   );
 
@@ -428,13 +431,13 @@ const FinalSearch = () => {
             if (
               feature &&
               feature.layer &&
-              feature.layer.id.startsWith('alt-route-line-')
+              (feature.layer.id.startsWith('alt-route-line-') ||
+                feature.layer.id.startsWith('alt-route-border-'))
             ) {
-              const idx = parseInt(feature.layer.id.replace('alt-route-line-', ''));
-              if (
-                !Number.isNaN(idx) &&
-                storedAlternativeRoutes[idx]
-              ) {
+              const idx = parseInt(
+                feature.layer.id.replace(/alt-route-(?:line|border)-/, '')
+              );
+              if (!Number.isNaN(idx) && storedAlternativeRoutes[idx]) {
                 handleSelectAlternativeRoute(storedAlternativeRoutes[idx]);
               }
             }


### PR DESCRIPTION
## Summary
- make altLayerIds include border layers
- handle clicks on alt-route border layers in FinalSearch page and RouteMap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c411326888332af2fb6687758ab27