### PR TITLE
Fix alternative route overlay logic

### DIFF
--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -700,7 +700,13 @@ const RoutingPage = () => {
         </div>
 
         {isMapModalOpen && (
-          <div className={`map-container ${isMapModalOpen ? 'open' : 'closed'} ${isInfoModalOpen ? 'dark-overlay' : ''} ${showAllRoutesView ? 'No-dark-overlay' : ''} ${isInfoModalOpen ? 'dark-overlay' : ''} ${showAlternativeRoutes ? 'No-dark-overlay' : ''}`}>
+          <div
+            className={`map-container ${isMapModalOpen ? 'open' : 'closed'} ${
+              !showAllRoutesView && !showAlternativeRoutes && isInfoModalOpen
+                ? 'dark-overlay'
+                : 'No-dark-overlay'
+            }`}
+          >
             <RouteMap
               userLocation={userLocation}
               routeSteps={routeData.steps}


### PR DESCRIPTION
## Summary
- clean up map overlay class toggles in Routing page so brightness changes correctly when showing alternative routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c43f0a75c8332b4adeccc29e5bc89