### PR TITLE
Implement route sharing feature

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -356,6 +356,27 @@ const FinalSearch = () => {
 
   const handleShareRoute = () => {
     setMenuOpen(false);
+    if (!origin.coordinates || !destination.coordinates) return;
+    const originCoords = `${origin.coordinates[0]},${origin.coordinates[1]}`;
+    const destCoords = `${destination.coordinates[0]},${destination.coordinates[1]}`;
+    const travel = transportMode === 'electric-car' ? 'driving' : 'walking';
+    const mapsUrl =
+      `https://www.google.com/maps/dir/?api=1&origin=${originCoords}&destination=${destCoords}&travelmode=${travel}`;
+
+    const shareData = {
+      title: intl.formatMessage({ id: 'shareRoute' }),
+      text: intl.formatMessage(
+        { id: 'routeSummary' },
+        { origin: origin.name, destination: destination.name }
+      ),
+      url: mapsUrl
+    };
+
+    if (navigator.share) {
+      navigator.share(shareData).catch(err => console.error('share failed', err));
+    } else {
+      window.open(mapsUrl, '_blank');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add a functional share button to `FinalSearch` that builds a Google Maps link
- enable sharing through the Web Share API or fall back to opening a new tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cde96c9ac8332ba11c0d672511da7