### PR TITLE
Implement route fit bounds on all route view

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -6,7 +6,9 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import osmStyle from '../../services/osmStyle';
 import GeoJsonOverlay from './GeoJsonOverlay';
 
-const RouteMap = ({
+import { forwardRef, useImperativeHandle } from 'react';
+
+const RouteMap = forwardRef(({
   userLocation,
   routeSteps,
   currentStep,
@@ -16,7 +18,7 @@ const RouteMap = ({
   routeGeo,
   alternativeRoutes = [],
   onSelectAlternativeRoute
-}) => {
+}, ref) => {
   const mapRef = useRef(null);
   const center = userLocation && userLocation.length === 2
     ? userLocation
@@ -111,6 +113,23 @@ const RouteMap = ({
       }
     }
   }, [routeGeo]);
+
+  // Expose a method to parent components for fitting bounds
+  const fitRouteBounds = () => {
+    if (mapRef.current && routeGeo) {
+      const coords = routeGeo.geometry?.coordinates || [];
+      if (coords.length > 0) {
+        const bounds = new maplibregl.LngLatBounds(
+          [coords[0][0], coords[0][1]],
+          [coords[0][0], coords[0][1]]
+        );
+        coords.forEach(([lng, lat]) => bounds.extend([lng, lat]));
+        mapRef.current.fitBounds(bounds, { padding: 80, duration: 700 });
+      }
+    }
+  };
+
+  useImperativeHandle(ref, () => ({ fitRouteBounds }));
 
   return (
     <Map

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import RouteMap from '../components/map/RouteMap';
@@ -11,6 +11,7 @@ import { toast } from 'react-toastify';
 
 const RoutingPage = () => {
   const intl = useIntl();
+  const routeMapRef = useRef(null);
   const [isMapModalOpen, setIsMapModalOpen] = useState(true);
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(true);
   const [routeData, setRouteData] = useState(null);
@@ -430,6 +431,9 @@ const RoutingPage = () => {
     setIs3DView(false); // Force 2D view
     setShowAllRoutesView(true);
     setIsInfoModalOpen(true);
+    if (routeMapRef.current && routeMapRef.current.fitRouteBounds) {
+      routeMapRef.current.fitRouteBounds();
+    }
   };
 
   const handleReturnToRoute = () => {
@@ -710,6 +714,7 @@ const RoutingPage = () => {
             }`}
           >
             <RouteMap
+              ref={routeMapRef}
               userLocation={userLocation}
               routeSteps={routeData.steps}
               currentStep={currentStep}


### PR DESCRIPTION
## Summary
- expose `fitRouteBounds` function from `RouteMap` with `forwardRef`
- call the new function when `همه مسیر` button is clicked so map zooms to full route
- wire up ref in `Routing` page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d764633648332a3d8b639b67b9eb4