### PR TITLE
fix alt route origin/destination

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -295,7 +295,9 @@ const FinalSearch = () => {
 
     const currentRoute = {
       geo: storedRouteGeo,
-      steps: storedRouteSteps
+      steps: storedRouteSteps,
+      from: storedOrigin?.name || origin.name,
+      to: storedDestination?.name || destination.name
     };
     const newAlternatives = storedAlternativeRoutes.filter(alt => alt !== route);
 
@@ -306,6 +308,9 @@ const FinalSearch = () => {
     storeSetRouteGeo(route.geo);
     storeSetRouteSteps(route.steps);
     storeSetAlternativeRoutes(newAlternatives);
+    sessionStorage.setItem('routeGeo', JSON.stringify(route.geo));
+    sessionStorage.setItem('routeSteps', JSON.stringify(route.steps));
+    sessionStorage.setItem('alternativeRoutes', JSON.stringify(newAlternatives));
   };
 
   const getTransportIcon = () => {

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -61,7 +61,15 @@ const RoutingPage = () => {
     if (sessGeo && sessSteps) {
       setRouteGeo(JSON.parse(sessGeo));
       setRouteSteps(JSON.parse(sessSteps));
-      setAlternativeRoutes(sessAlts ? JSON.parse(sessAlts) : []);
+      let alts = sessAlts ? JSON.parse(sessAlts) : [];
+      const originObj = sessOrigin ? JSON.parse(sessOrigin) : origin;
+      const destObj = sessDestination ? JSON.parse(sessDestination) : destination;
+      alts = alts.map(a => ({
+        ...a,
+        from: a.from || originObj?.name || '',
+        to: a.to || destObj?.name || ''
+      }));
+      setAlternativeRoutes(alts);
       if (sessOrigin) setOrigin(JSON.parse(sessOrigin));
       if (sessDestination) setDestination(JSON.parse(sessDestination));
     }
@@ -455,7 +463,12 @@ const RoutingPage = () => {
       return;
     }
 
-    const currentRoute = { geo: routeGeo, steps: routeSteps };
+    const currentRoute = {
+      geo: routeGeo,
+      steps: routeSteps,
+      from: origin?.name || '',
+      to: destination?.name || ''
+    };
     const newAlternatives = alternativeRoutes.filter(
       (alt) => alt.geo !== route.geo
     );
@@ -467,6 +480,9 @@ const RoutingPage = () => {
     setRouteGeo(route.geo);
     setRouteSteps(route.steps);
     setAlternativeRoutes(newAlternatives);
+    sessionStorage.setItem('routeGeo', JSON.stringify(route.geo));
+    sessionStorage.setItem('routeSteps', JSON.stringify(route.steps));
+    sessionStorage.setItem('alternativeRoutes', JSON.stringify(newAlternatives));
     setCurrentStep(0);
     setIsRoutingActive(false);
     setShowAlternativeRoutes(false);


### PR DESCRIPTION
## Summary
- ensure alternative routes restored from session include origin/destination
- keep origin/destination when swapping routes
- persist updated route data in session

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d7746e2a0833285e0867c93abce44