### PR TITLE
Fix missing via info in alternative routes

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -297,7 +297,8 @@ const FinalSearch = () => {
       geo: storedRouteGeo,
       steps: storedRouteSteps,
       from: storedOrigin?.name || origin.name,
-      to: storedDestination?.name || destination.name
+      to: storedDestination?.name || destination.name,
+      via: route.via || []
     };
     const newAlternatives = storedAlternativeRoutes.filter(alt => alt !== route);
 

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -471,7 +471,8 @@ const RoutingPage = () => {
       geo: routeGeo,
       steps: routeSteps,
       from: origin?.name || '',
-      to: destination?.name || ''
+      to: destination?.name || '',
+      via: route.via || []
     };
     const newAlternatives = alternativeRoutes.filter(
       (alt) => alt.geo !== route.geo


### PR DESCRIPTION
## Summary
- preserve via (scene) info when storing previous route
- keep via when selecting alternative routes in FinalSearch page

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686d7944dd3883329a6202420d26143c