### PR TITLE
Enable editing origin/destination from map

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -578,7 +578,10 @@ const FinalSearch = () => {
         </div>
 
         <div className="location-section">
-          <div className="location-input origin-input">
+          <div
+            className="location-input origin-input"
+            onClick={() => navigate('/mpr?edit=origin')}
+          >
             <div className="location-details">
               <div className="location-name">{origin.name}</div>
             </div>
@@ -608,7 +611,10 @@ const FinalSearch = () => {
             </button>
           </div>
 
-          <div className="location-input destination-input">
+          <div
+            className="location-input destination-input"
+            onClick={() => navigate('/mpr?edit=destination')}
+          >
             <div className="location-details">
               <div className="location-name">{destination.name}</div>
             </div>

--- a/src/styles/FinalSearch.css
+++ b/src/styles/FinalSearch.css
@@ -180,6 +180,7 @@
   position: relative;
   border: 1px solid #e0e0e0;
   margin: 5px 0;
+  cursor: pointer;
 }
 
 .origin-input {


### PR DESCRIPTION
## Summary
- link origin and destination boxes on the Final Search page to the map routing page
- add query param handling in MapRouting to open edit modals
- initialize map routing page with stored origin/destination
- avoid immediate redirect back to Final Search on first render
- show pointer cursor on location inputs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d894d2b108332812c89060bf82b09