### PR TITLE
Enable editing origin/destination from map

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -1,6 +1,6 @@
 // src/pages/FinalSearch.jsx
 import React, { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import Map, { Marker, Source, Layer, Popup } from 'react-map-gl';
 import GeoJsonOverlay from '../components/map/GeoJsonOverlay';
@@ -578,14 +578,17 @@ const FinalSearch = () => {
         </div>
 
         <div className="location-section">
-          <div className="location-input origin-input">
+          <Link
+            to="/mpr?edit=origin"
+            className="location-input origin-input"
+          >
             <div className="location-details">
               <div className="location-name">{origin.name}</div>
             </div>
             <div className={`current-location-label ${isSwapButton ? 'visible' : 'hidden'}`}>
               <FormattedMessage id="mapCurrentLocationName" />
             </div>
-          </div>
+          </Link>
 
           <div className="swap-container">
             <button className="swap-btn" onClick={swapLocations}>
@@ -608,11 +611,14 @@ const FinalSearch = () => {
             </button>
           </div>
 
-          <div className="location-input destination-input">
+          <Link
+            to="/mpr?edit=destination"
+            className="location-input destination-input"
+          >
             <div className="location-details">
               <div className="location-name">{destination.name}</div>
             </div>
-          </div>
+          </Link>
         </div>
       </div>
 

--- a/src/styles/FinalSearch.css
+++ b/src/styles/FinalSearch.css
@@ -180,6 +180,9 @@
   position: relative;
   border: 1px solid #e0e0e0;
   margin: 5px 0;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
 }
 
 .origin-input {


### PR DESCRIPTION
## Summary
- link origin and destination boxes on the Final Search page to the map routing page using `<Link>`
- style link-based location inputs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d894d2b108332812c89060bf82b09