### PR TITLE
Add QR scanning feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import MapRouting from './pages/MapRouting';
 import Routing from './pages/Routing';
 import RouteOverview from './pages/RouteOverview';
 import Location from './pages/Location';
+import QRScan from './pages/QRScan';
 import { Header } from './components/layout/Header';
 import { Footer } from './components/layout/Footer';
 import './App.css';
@@ -88,6 +89,7 @@ const AppContent = () => {
           <Route path="/mpr" element={<MapRouting/>} />
           <Route path="/rng" element={<Routing/>} />
           <Route path="/location" element={<Location />} />
+          <Route path="/qr-scan" element={<QRScan />} />
         </Routes>
       </main>
       {!hideHeaderFooter && <Footer />}

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -178,4 +178,6 @@
   ,"stepPassDoor": "اعبر من {name}"
   ,"stepArriveDestination": "الوصول إلى {name}"
   ,"stepNumber": "الخطوة {num}"
+  ,"qrScanInstruction": "ضع رمز QR داخل الإطار"
+  ,"qrScanError": "فشل قراءة رمز QR"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -179,4 +179,6 @@
   ,"stepArriveDestination": "Arrive at {name}"
   ,"stepNumber": "Step {num}"
   ,"landmarkSuffix": "turn toward {name} and go {distance} meters ahead"
+  ,"qrScanInstruction": "Align the QR code within the frame"
+  ,"qrScanError": "Failed to read QR code"
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -179,4 +179,6 @@
   ,"stepArriveDestination": "رسیدن به مقصد {name}"
   ,"stepNumber": "گام {num}"
   ,"landmarkSuffix": "به سمت {name} بچرخید و {distance} متر به جلو بروید"
+  ,"qrScanInstruction": "کد QR را در کادر قرار دهید"
+  ,"qrScanError": "خواندن کد QR ناموفق بود"
 }

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -178,4 +178,6 @@
   ,"stepPassDoor": "{name} سے گزریں"
   ,"stepArriveDestination": "{name} پر پہنچیں"
   ,"stepNumber": "قدم {num}"
+  ,"qrScanInstruction": "QR کوڈ کو فریم کے اندر رکھیں"
+  ,"qrScanError": "QR کوڈ پڑھا نہیں جا سکا"
 }

--- a/src/pages/QRScan.jsx
+++ b/src/pages/QRScan.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
+import { QrScanner } from '@yudiel/react-qr-scanner';
+import { useGPSStore } from '../store/gpsStore.js';
+
+const QRScan = () => {
+  const [result, setResult] = useState('');
+  const navigate = useNavigate();
+  const updateCurrentLocation = useGPSStore(state => state.updateCurrentLocation);
+  const addQRCodeLocation = useGPSStore(state => state.addQRCodeLocation);
+
+  const handleDecode = (text) => {
+    setResult(text);
+    try {
+      const url = new URL(text);
+      const lat = url.searchParams.get('lat');
+      const lng = url.searchParams.get('lng');
+      if (lat && lng) {
+        sessionStorage.setItem('qrLat', lat);
+        sessionStorage.setItem('qrLng', lng);
+        const loc = { lat: parseFloat(lat), lng: parseFloat(lng) };
+        updateCurrentLocation({ coords: loc, timestamp: Date.now() });
+        addQRCodeLocation(text, loc);
+        navigate('/mpr');
+      }
+    } catch (e) {
+      console.error('invalid qr data', e);
+    }
+  };
+
+  return (
+    <div className="qr-scan-page">
+      <h2><FormattedMessage id="qrScan" /></h2>
+      <div className="scanner-container">
+        <QrScanner
+          onDecode={handleDecode}
+          onError={(err) => console.error(err?.message)}
+        />
+      </div>
+      {result && (
+        <div className="scan-result-container">
+          <div className="qr-data">{result}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QRScan;


### PR DESCRIPTION
## Summary
- implement `/qr-scan` page for QR code scanning
- route new page in app router
- add translation strings for scanning instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d8e8ebf14833297a8913ef299323a