### PR TITLE
Fix routing to use session data

### DIFF
--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -89,6 +89,14 @@ const RoutingPage = () => {
       origin.coordinates?.[0] !== lat ||
       origin.coordinates?.[1] !== lng;
 
+    const sessGeo = sessionStorage.getItem('routeGeo');
+    const sessSteps = sessionStorage.getItem('routeSteps');
+    if (sessGeo && sessSteps && !originChanged) {
+      // Session data already provides the route; the first effect will
+      // load it into state so skip rebuilding here
+      return;
+    }
+
     if (!routeSteps.length || originChanged) {
       const newOrigin = {
         name: intl.formatMessage({ id: 'mapCurrentLocationName' }),


### PR DESCRIPTION
## Summary
- skip rebuilding the route on `/rng` if session data already has route information

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d9038e45c833281bb496d79e155e4