### PR TITLE
Toggle GPS tracking mode

### DIFF
--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -371,7 +371,7 @@ const MapRoutingPage = () => {
         />
         <button
           className={`map-gps-button ${isTracking ? 'active' : ''}`}
-          onClick={() => setIsTracking(true)}
+          onClick={() => setIsTracking((t) => !t)}
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path stroke="none" d="M0 0h24v24H0z" fill="none" />


### PR DESCRIPTION
## Summary
- make map GPS button toggle tracking so users can reenable centering

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6872638e63b08332ba5b2e6eee819bb8