### PR TITLE
Handle search input case sensitivity

### DIFF
--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -158,7 +158,9 @@ const MapRoutingPage = () => {
   };
 
   const handleInputChange = (e) => {
-    setSearchQuery(e.target.value);
+    // Normalize the search query to lowercase to allow
+    // case-insensitive matching against destination names
+    setSearchQuery(e.target.value.toLowerCase());
   };
 
   // Load geojson data whenever the selected language changes


### PR DESCRIPTION
## Summary
- normalize MapRouting search input values to lowercase for consistent lookup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68726470ee808332be7101caa2031a78