### PR TITLE
Use language specific geojson

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"predeploy": "npm run build",
 		"deploy": "gh-pages -d dist",
                 "generate-pwa-assets": "pwa-assets-generator",
-                "test": "node tests/routeAnalysis.test.js"
+                "test": "node tests/routeAnalysis.test.js && node tests/geojsonPath.test.js"
         },
 	"dependencies": {
 		"@turf/turf": "^7.2.0",

--- a/src/utils/geojsonPath.js
+++ b/src/utils/geojsonPath.js
@@ -1,6 +1,5 @@
 export function buildGeoJsonPath(language = 'fa') {
-  const base = import.meta.env.BASE_URL;
-  return language === 'fa'
-    ? `${base}data/data14040411.geojson`
-    : `${base}data/data14040411_${language}.geojson`;
+  const base = import.meta.env.BASE_URL || '/';
+  const suffix = language && language !== 'fa' ? `_${language}` : '';
+  return `${base}data/data14040411${suffix}.geojson`;
 }

--- a/tests/geojsonPath.test.js
+++ b/tests/geojsonPath.test.js
@@ -1,0 +1,22 @@
+import assert from 'assert';
+import { buildGeoJsonPath } from '../src/utils/geojsonPath.js';
+
+// Mock BASE_URL for tests
+import.meta.env = { BASE_URL: '/' };
+
+assert.strictEqual(
+  buildGeoJsonPath('fa'),
+  '/data/data14040411.geojson',
+  'should build default fa path'
+);
+assert.strictEqual(
+  buildGeoJsonPath('en'),
+  '/data/data14040411_en.geojson',
+  'should build english path'
+);
+assert.strictEqual(
+  buildGeoJsonPath('ar'),
+  '/data/data14040411_ar.geojson',
+  'should build arabic path'
+);
+console.log('geojsonPath tests passed');


### PR DESCRIPTION
## Summary
- return language specific geojson file path
- test geojson path builder
- run all tests via npm script

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687268b239648332909d17034976f3db