### PR TITLE
Fix destination cleared when editing origin

### DIFF
--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -86,9 +86,25 @@ const MapRoutingPage = () => {
 
     if (returnToFinalSearch === 'true') {
       if (activeInput === 'origin') {
+        const storedDest = sessionStorage.getItem('currentDestination');
+        if (storedDest) {
+          try {
+            setSelectedDestination(JSON.parse(storedDest));
+          } catch (err) {
+            console.error('failed to parse currentDestination', err);
+          }
+        }
         setShowOriginModal(true);
         setActiveInput('origin');
       } else if (activeInput === 'destination') {
+        const storedOrig = sessionStorage.getItem('currentOrigin');
+        if (storedOrig) {
+          try {
+            setUserLocation(JSON.parse(storedOrig));
+          } catch (err) {
+            console.error('failed to parse currentOrigin', err);
+          }
+        }
         setShowDestinationModal(true);
         setActiveInput('destination');
       }


### PR DESCRIPTION
## Summary
- keep stored destination when returning to MapRouting to edit origin
- keep stored origin when editing destination

## Testing
- `npm test` *(fails: cannot find module 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_6872c20638e08332931723b48f8a6aa7