### PR TITLE
Fix origin not preserved when updating from map

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -134,6 +134,7 @@ const FinalSearch = () => {
   const handleOriginClick = () => {
     sessionStorage.setItem('returnToFinalSearch', 'true');
     sessionStorage.setItem('activeInput', 'origin');
+    sessionStorage.setItem('currentOrigin', JSON.stringify(origin));
     sessionStorage.setItem('currentDestination', JSON.stringify(destination));
     navigate('/mpr', { state: { showOriginModal: true } });
   };

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -87,11 +87,19 @@ const MapRoutingPage = () => {
     if (returnToFinalSearch === 'true') {
       if (activeInput === 'origin') {
         const storedDest = sessionStorage.getItem('currentDestination');
+        const storedOrig = sessionStorage.getItem('currentOrigin');
         if (storedDest) {
           try {
             setSelectedDestination(JSON.parse(storedDest));
           } catch (err) {
             console.error('failed to parse currentDestination', err);
+          }
+        }
+        if (storedOrig) {
+          try {
+            setUserLocation(JSON.parse(storedOrig));
+          } catch (err) {
+            console.error('failed to parse currentOrigin', err);
           }
         }
         setShowOriginModal(true);


### PR DESCRIPTION
## Summary
- keep user's origin when returning from Final Search
- restore origin inside MapRouting

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_6872c45e7764833290f83cd34b210a31