### PR TITLE
Prevent GPS from overriding custom origin

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -141,20 +141,25 @@ const MapComponent = ({
       });
     };
 
-    navigator.geolocation.getCurrentPosition(success, err, {
-      enableHighAccuracy: false,
-      timeout: 10000,
-      maximumAge: 60000
-    });
-    
-    const watchId = navigator.geolocation.watchPosition(success, err, {
-      enableHighAccuracy: false,
-      maximumAge: 0,
-      timeout: 10000
-    });
-    
-    return () => navigator.geolocation.clearWatch(watchId);
-  }, [setUserLocation, intl]);
+    let watchId;
+    if (isTracking) {
+      navigator.geolocation.getCurrentPosition(success, err, {
+        enableHighAccuracy: false,
+        timeout: 10000,
+        maximumAge: 60000
+      });
+
+      watchId = navigator.geolocation.watchPosition(success, err, {
+        enableHighAccuracy: false,
+        maximumAge: 0,
+        timeout: 10000
+      });
+    }
+
+    return () => {
+      if (watchId) navigator.geolocation.clearWatch(watchId);
+    };
+  }, [setUserLocation, intl, isTracking]);
 
   // Update user location and optionally center map when it changes
   useEffect(() => {

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -266,6 +266,7 @@ const MapRoutingPage = () => {
 
   const handleMapSelection = () => {
     setIsSelectingFromMap(true);
+    setIsTracking(false);
     setShowDestinationModal(false);
     setShowOriginModal(false);
   };


### PR DESCRIPTION
## Summary
- stop geolocation watch when user tracking is disabled
- disable tracking when selecting a location from the map

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6872ccc735e08332889c6adb584fac9f