### PR TITLE
Fix origin reset on destination edit

### DIFF
--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -115,6 +115,9 @@ const MapRoutingPage = () => {
         }
         setShowDestinationModal(true);
         setActiveInput('destination');
+        // Disable GPS tracking when editing only the destination
+        // to avoid overwriting the origin with the current location
+        setIsTracking(false);
       }
 
       // Clear the flags


### PR DESCRIPTION
## Summary
- prevent MapRouting from tracking GPS when editing only the destination

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687423f250b48332b15e61537603e654