### PR TITLE
Handle low accuracy GPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"predeploy": "npm run build",
 		"deploy": "gh-pages -d dist",
                 "generate-pwa-assets": "pwa-assets-generator",
-                "test": "node tests/routeAnalysis.test.js && node tests/geojsonPath.test.js"
+                "test": "node tests/routeAnalysis.test.js && node tests/geojsonPath.test.js && node tests/gpsAccuracy.test.js"
         },
 	"dependencies": {
 		"@turf/turf": "^7.2.0",

--- a/src/services/AdvancedDeadReckoningService.js
+++ b/src/services/AdvancedDeadReckoningService.js
@@ -518,7 +518,13 @@ class AdvancedDeadReckoningService {
             position.lng
         );
 
-        // به‌روزرسانی فیلتر کالمن با اندازه‌گیری GPS جدید  
+        // اگر دقت موقعیت پایین باشد، فیلتر کالمن را به‌روز نکنید
+        if (accuracy > 20) {
+            console.log('GPS accuracy too low:', accuracy);
+            return;
+        }
+
+        // به‌روزرسانی فیلتر کالمن با اندازه‌گیری GPS جدید
         this.kalmanFilter.update(
             {
                 x_gps: relativePosition.x,

--- a/tests/gpsAccuracy.test.js
+++ b/tests/gpsAccuracy.test.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import drService from '../src/services/AdvancedDeadReckoningService.js';
+
+// Start the service with an initial reference position
+if (!drService.isActive) {
+    drService.toggle({ lat: 0, lng: 0 });
+}
+
+const initialPosition = { ...drService.currentPosition };
+const initialPathLength = drService.path.length;
+
+// Send GPS data with poor accuracy (>20 meters)
+drService.processGpsData({ lat: 0.0001, lng: 0.0001 }, 30);
+
+// Position and path should not change
+assert.strictEqual(drService.currentPosition.x, initialPosition.x);
+assert.strictEqual(drService.currentPosition.y, initialPosition.y);
+assert.strictEqual(drService.path.length, initialPathLength);
+assert.ok(drService.isActive, 'service should remain active');
+
+// Stop the service to clean up
+if (drService.isActive) {
+    drService.toggle();
+}
+
+console.log('gps accuracy handling test passed');


### PR DESCRIPTION
## Summary
- skip Kalman filter updates when GPS accuracy is poor
- add a test covering handling of inaccurate GPS data
- include the new test in npm test script

## Testing
- `npm test` *(fails: Cannot find package 'zustand' imported from src/store/langStore.js)*

------
https://chatgpt.com/codex/tasks/task_e_687525904cc4833286e453df49956f57