### PR TITLE
Fix map 3‑D mode reset after WebGL context loss

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -72,6 +72,24 @@ const RouteMap = forwardRef(({
     }
   }, [is3DView]);
 
+  // Restore pitch if WebGL context is lost and then restored
+  useEffect(() => {
+    if (!mapRef.current) return;
+    const canvas = mapRef.current.getCanvas();
+    const handleContextLost = e => {
+      e.preventDefault();
+    };
+    const handleContextRestored = () => {
+      mapRef.current.setPitch(is3DView ? 60 : 0);
+    };
+    canvas.addEventListener('webglcontextlost', handleContextLost, false);
+    canvas.addEventListener('webglcontextrestored', handleContextRestored, false);
+    return () => {
+      canvas.removeEventListener('webglcontextlost', handleContextLost, false);
+      canvas.removeEventListener('webglcontextrestored', handleContextRestored, false);
+    };
+  }, [is3DView]);
+
   // Rotate map based on user heading with smoothing to avoid sudden jumps
   const lastHeading = useRef(null);
   useEffect(() => {


### PR DESCRIPTION
## Summary
- handle `webglcontextlost` and `webglcontextrestored` events in `RouteMap`
- restore the map pitch when the WebGL context resets so 3‑D view is preserved

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6876171380c0833287ead066bc08c2e0