### PR TITLE
Parse id param for location page

### DIFF
--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -20,7 +20,20 @@ const labelToValueMap = Object.values(subGroups).flat().reduce((acc, sg) => {
 const Location = () => {
   const navigate = useNavigate();
   const currentLocation = useReactLocation();
-  const locationId = new URLSearchParams(currentLocation.search).get('id');
+
+  const getSearchParams = () => {
+    let search = currentLocation.search || window.location.search;
+    if (!search && window.location.hash.includes('?')) {
+      search = window.location.hash.split('?')[1];
+      if (search) search = '?' + search;
+    }
+    if (search && search.includes('&amp;')) {
+      search = search.replace(/&amp;/g, '&');
+    }
+    return new URLSearchParams(search);
+  };
+
+  const locationId = getSearchParams().get('id');
   const intl = useIntl();
   const [activeSlide, setActiveSlide] = useState(0);
   const [comment, setComment] = useState('');


### PR DESCRIPTION
## Summary
- ensure location page reads `id` query parameter regardless of query position

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687680352b908332a36f68c4369a1eb2