### PR TITLE
Hide alternative routes when DR active

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -25,15 +25,18 @@ const RouteMap = forwardRef(({
   const center = userLocation && userLocation.length === 2
     ? userLocation
     : [36.297, 59.606]; // Default to Imam Reza Shrine coordinates
-  const altLayerIds = alternativeRoutes.flatMap((_, idx) => [
-    `alt-route-line-${idx}`,
-    `alt-route-border-${idx}`
-  ]);
 
   const [drPosition, setDrPosition] = useState(null);
   const [drGeoPath, setDrGeoPath] = useState([]);
   const [isDrActive, setIsDrActive] = useState(advancedDeadReckoningService.isActive);
   const [heading, setHeading] = useState(0);
+
+  const altLayerIds = !isDrActive
+    ? alternativeRoutes.flatMap((_, idx) => [
+        `alt-route-line-${idx}`,
+        `alt-route-border-${idx}`
+      ])
+    : [];
 
   useEffect(() => {
     const remove = advancedDeadReckoningService.addListener(data => {
@@ -290,12 +293,13 @@ const RouteMap = forwardRef(({
         </Source>
       )}
 
-      {alternativeRoutes.map((alt, idx) => (
-        <Source key={idx} id={`alt-route-${idx}`} type="geojson" data={alt.geo}>
-          <Layer
-            id={`alt-route-border-${idx}`}
-            type="line"
-            paint={{
+      {!isDrActive &&
+        alternativeRoutes.map((alt, idx) => (
+          <Source key={idx} id={`alt-route-${idx}`} type="geojson" data={alt.geo}>
+            <Layer
+              id={`alt-route-border-${idx}`}
+              type="line"
+              paint={{
               'line-color': 'white',
               'line-width': 8,
               'line-dasharray': [1, 2] // Creates dotted pattern
@@ -313,7 +317,7 @@ const RouteMap = forwardRef(({
             layout={{ 'line-cap': 'round', 'line-join': 'round' }}
           />
         </Source>
-      ))}
+        ))}
 
       <GeoJsonOverlay />
     </Map>

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -72,6 +72,12 @@ const RoutingPage = () => {
   }, []);
 
   useEffect(() => {
+    if (isDrActive) {
+      setShowAlternativeRoutes(false);
+    }
+  }, [isDrActive]);
+
+  useEffect(() => {
     const sessGeo = sessionStorage.getItem('routeGeo');
     const sessSteps = sessionStorage.getItem('routeSteps');
     const sessAlts = sessionStorage.getItem('alternativeRoutes');
@@ -848,7 +854,7 @@ const RoutingPage = () => {
             isMapModalOpen={isMapModalOpen}
             is3DView={is3DView}
             routeGeo={routeGeo}
-            alternativeRoutes={routeData.alternativeRoutes}
+            alternativeRoutes={isDrActive ? [] : routeData.alternativeRoutes}
             onSelectAlternativeRoute={handleSelectAlternativeRoute}
           />
           <DeadReckoningControls
@@ -902,7 +908,7 @@ const RoutingPage = () => {
                 </button>
               </div>
             </div>
-          ) : showAlternativeRoutes ? (
+          ) : showAlternativeRoutes && !isDrActive ? (
             <div className="alternative-routes-view">
               <button className="return-to-route-button5" onClick={handleReturnFromAlternativeRoutes}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
@@ -1038,13 +1044,17 @@ const RoutingPage = () => {
                       </div>
                       <span><FormattedMessage id="allRoutes" /></span>
                     </button>
-                    <span className="sdivider"></span>
-                    <button className="route-button" onClick={handleShowAlternativeRoutes}>
-                      <div className="button-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-route-alt-left"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M8 3h-5v5" /><path d="M16 3h5v5" /><path d="M3 3l7.536 7.536a5 5 0 0 1 1.464 3.534v6.93" /><path d="M18 6.01v-.01" /><path d="M16 8.02v-.01" /><path d="M14 10v.01" /></svg>
-                      </div>
-                      <span><FormattedMessage id="otherRoutes" /></span>
-                    </button>
+                    {!isDrActive && routeData.alternativeRoutes.length > 0 && (
+                      <>
+                        <span className="sdivider"></span>
+                        <button className="route-button" onClick={handleShowAlternativeRoutes}>
+                          <div className="button-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-route-alt-left"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M8 3h-5v5" /><path d="M16 3h5v5" /><path d="M3 3l7.536 7.536a5 5 0 0 1 1.464 3.534v6.93" /><path d="M18 6.01v-.01" /><path d="M16 8.02v-.01" /><path d="M14 10v.01" /></svg>
+                          </div>
+                          <span><FormattedMessage id="otherRoutes" /></span>
+                        </button>
+                      </>
+                    )}
                   </div>
                 </>
               )}


### PR DESCRIPTION
## Summary
- hide alt layers on map while Dead Reckoning is active
- prevent alternative routes view and button in DR mode

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6876852dbcd08332b4eb66e04016a7db