### PR TITLE
Fix translations for all languages

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -183,5 +183,10 @@
   "emergencySubmissionSuccess": "تم إرسال طلب المساعدة بنجاح",
   "emergencySubmissionError": "خطأ في إرسال طلب المساعدة",
   "emergencySelectType": "الرجاء اختيار نوع الطلب",
-  "emergencyEnterDetails": "الرجاء إدخال مزيد من التفاصيل"
+  "emergencyEnterDetails": "الرجاء إدخال مزيد من التفاصيل",
+  "landmarkSuffix": "ثم اتجه نحو {name} وتقدم {distance} متراً إلى الأمام",
+  "fa": "الفارسية",
+  "ur": "الأردية",
+  "ar": "العربية",
+  "en": "الإنجليزية"
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -184,5 +184,9 @@
   "emergencySubmissionSuccess": "درخواست کمک شما با موفقیت ارسال شد",
   "emergencySubmissionError": "خطا در ارسال درخواست کمک",
   "emergencySelectType": "لطفاً نوع درخواست کمک را انتخاب کنید",
-  "emergencyEnterDetails": "لطفاً توضیحات بیشتری وارد کنید"
+  "emergencyEnterDetails": "لطفاً توضیحات بیشتری وارد کنید",
+  "fa": "فارسی",
+  "ur": "اردو",
+  "ar": "عربی",
+  "en": "انگلیسی"
 }

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -183,5 +183,10 @@
   "emergencySubmissionSuccess": "آپ کی مدد کی درخواست کامیابی کے ساتھ بھیج دی گئی",
   "emergencySubmissionError": "مدد کی درخواست بھیجنے میں خرابی",
   "emergencySelectType": "براہ کرم مدد کی قسم منتخب کریں",
-  "emergencyEnterDetails": "براہ کرم مزید تفصیلات درج کریں"
+  "emergencyEnterDetails": "براہ کرم مزید تفصیلات درج کریں",
+  "landmarkSuffix": "{name} کی طرف مڑیں اور {distance} میٹر آگے بڑھیں",
+  "fa": "فارسی",
+  "ur": "اردو",
+  "ar": "عربی",
+  "en": "انگریزی"
 }


### PR DESCRIPTION
## Summary
- add missing `landmarkSuffix` text in Arabic and Urdu translation files
- provide language names for Arabic, English, Farsi and Urdu in all translation files

## Testing
- `npm test` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68768abbddb08332acd22c791d3a621b