### PR TITLE
Show version with update alert

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1030,6 +1030,13 @@ body {
   font-weight: normal;
 }
 
+.app-version {
+  margin-top: 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: #555;
+}
+
 /* ICON STYLES */
 .item-icon {
   width: 24px;

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -190,5 +190,7 @@
   "ar": "العربية",
   "en": "الإنجليزية",
   "gpsOfflineMessage": "جهاز تحديد المواقع الخاص بك مغلق",
-  "stepPrefix": "الخطوة {num} - "
+  "stepPrefix": "الخطوة {num} - ",
+  "appVersionLabel": "إصدار التطبيق: {version}",
+  "newVersionAvailable": "إصدار جديد {version} متوفر"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -190,5 +190,7 @@
   "ar": "Arabic",
   "en": "English",
   "gpsOfflineMessage": "Your GPS is off",
-  "stepPrefix": "Step {num} - "
+  "stepPrefix": "Step {num} - ",
+  "appVersionLabel": "Version: {version}",
+  "newVersionAvailable": "New version {version} is available"
 }

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -190,5 +190,7 @@
   "ar": "عربی",
   "en": "انگلیسی",
   "gpsOfflineMessage": "GPS دستگاه شما خاموش است",
-  "stepPrefix": "گام {num} - "
+  "stepPrefix": "گام {num} - ",
+  "appVersionLabel": "نسخه نرم‌افزار: {version}",
+  "newVersionAvailable": "نسخه جدید {version} در دسترس است"
 }

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -190,5 +190,7 @@
   "ar": "عربی",
   "en": "انگریزی",
   "gpsOfflineMessage":  "آپ کا GPS ڈیوائس بند ہے",
-  "stepPrefix": "قدم {num} - "
+  "stepPrefix": "قدم {num} - ",
+  "appVersionLabel": "ایپ ورژن: {version}",
+  "newVersionAvailable": "نیا ورژن {version} دستیاب ہے"
 }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,12 +1,24 @@
 // src/pages/Profile.jsx
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import logo from '../assets/images/logo.png';
+import packageInfo from '../../package.json';
 
 function Profile() {
   const navigate = useNavigate();
   const intl = useIntl();
+  const appVersion = packageInfo.version;
+
+  useEffect(() => {
+    const savedVersion = localStorage.getItem('appVersion');
+    if (savedVersion && savedVersion !== appVersion) {
+      toast.info(intl.formatMessage({ id: 'newVersionAvailable' }, { version: appVersion }));
+    }
+    localStorage.setItem('appVersion', appVersion);
+  }, [appVersion, intl]);
 
   return (
     <div className="profile-container">
@@ -230,6 +242,9 @@ function Profile() {
             <span className="item-arrow">›</span>
           </div>
         </div>
+      </div>
+      <div className="app-version">
+        <FormattedMessage id="appVersionLabel" values={{ version: appVersion }} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show version on profile
- trigger toast when version changes
- add translations for version strings
- style version text

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687a5de4b17c83329185fe57da14719e