### PR TITLE
Update QR location handling

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -7,6 +7,7 @@ import osmStyle from '../../services/osmStyle';
 import { useLangStore } from '../../store/langStore';
 import { buildGeoJsonPath } from '../../utils/geojsonPath.js';
 import { groups } from '../groupData';
+import { getLocationTitleById } from '../../utils/getLocationTitle';
 
 const groupColors = {
   sahn: '#4caf50',
@@ -91,20 +92,28 @@ const MapComponent = ({
     const shrineCoords = { lat: 36.2880, lng: 59.6157 };
     
     if (storedLat && storedLng) {
-      const coords = { 
-        lat: parseFloat(storedLat), 
-        lng: parseFloat(storedLng) 
+      const coords = {
+        lat: parseFloat(storedLat),
+        lng: parseFloat(storedLng)
       };
       setUserCoords(coords);
-      setUserLocation({
-        name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
-        coordinates: [coords.lat, coords.lng]
-      });
-      setViewState(v => ({ 
-        ...v, 
-        latitude: coords.lat, 
-        longitude: coords.lng, 
-        zoom: 18 
+      (async () => {
+        let name = intl.formatMessage({ id: 'mapCurrentLocationName' });
+        const qrId = sessionStorage.getItem('qrId');
+        if (qrId) {
+          const title = await getLocationTitleById(qrId);
+          if (title) name = title;
+        }
+        setUserLocation({
+          name,
+          coordinates: [coords.lat, coords.lng]
+        });
+      })();
+      setViewState(v => ({
+        ...v,
+        latitude: coords.lat,
+        longitude: coords.lng,
+        zoom: 18
       }));
       return; // Skip GPS if QR code exists
     }

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -6,6 +6,7 @@ import { groups } from '../components/groupData';
 import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
+import { getLocationTitleById } from '../utils/getLocationTitle';
 import { useSearchStore } from '../store/searchStore';
 import '../styles/MapRouting.css';
 
@@ -34,6 +35,20 @@ const MapRoutingPage = () => {
   const [isTracking, setIsTracking] = useState(true);
   const [mapSelectedLocation, setMapSelectedLocation] = useState(null);
   const [selectedCategory, setSelectedCategory] = useState(null);
+
+  useEffect(() => {
+    const id = sessionStorage.getItem('qrId');
+    if (storedLat && storedLng && id) {
+      getLocationTitleById(id).then((title) => {
+        if (title) {
+          setUserLocation({
+            name: title,
+            coordinates: [parseFloat(storedLat), parseFloat(storedLng)]
+          });
+        }
+      });
+    }
+  }, [storedLat, storedLng, language]);
 
   const setOriginStore = useRouteStore(state => state.setOrigin);
   const setDestinationStore = useRouteStore(state => state.setDestination);
@@ -259,10 +274,20 @@ const MapRoutingPage = () => {
   };
 
   const handleCurrentLocationSelect = () => {
-    setUserLocation((prev) => ({
-      ...prev,
-      name: intl.formatMessage({ id: 'mapCurrentLocationName' })
-    }));
+    const id = sessionStorage.getItem('qrId');
+    if (storedLat && storedLng && id) {
+      getLocationTitleById(id).then((title) => {
+        setUserLocation({
+          name: title || intl.formatMessage({ id: 'mapCurrentLocationName' }),
+          coordinates: [parseFloat(storedLat), parseFloat(storedLng)]
+        });
+      });
+    } else {
+      setUserLocation((prev) => ({
+        ...prev,
+        name: intl.formatMessage({ id: 'mapCurrentLocationName' })
+      }));
+    }
     setShowOriginModal(false);
   };
 

--- a/src/pages/QRScan.jsx
+++ b/src/pages/QRScan.jsx
@@ -16,9 +16,11 @@ const QRScan = () => {
       const url = new URL(text);
       const lat = url.searchParams.get('lat');
       const lng = url.searchParams.get('lng');
+      const id = url.searchParams.get('id');
       if (lat && lng) {
         sessionStorage.setItem('qrLat', lat);
         sessionStorage.setItem('qrLng', lng);
+        if (id) sessionStorage.setItem('qrId', id);
         const loc = { lat: parseFloat(lat), lng: parseFloat(lng) };
         updateCurrentLocation({ coords: loc, timestamp: Date.now() });
         addQRCodeLocation(text, loc);

--- a/src/utils/getLocationTitle.js
+++ b/src/utils/getLocationTitle.js
@@ -1,0 +1,19 @@
+import { useLangStore } from '../store/langStore';
+
+export async function getLocationTitleById(id) {
+  try {
+    const lang = useLangStore.getState().language;
+    const res = await fetch('./data/locationData.json');
+    const data = await res.json();
+    const loc = Array.isArray(data) ? data.find(l => l.id === id) : data;
+    if (!loc) return null;
+    const { title } = loc;
+    if (title && typeof title === 'object' && !Array.isArray(title)) {
+      return title[lang] || title.fa || Object.values(title)[0];
+    }
+    return title || null;
+  } catch (err) {
+    console.error('failed to load location title', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- store scanned location ID in session
- show QR location name in map pages using `getLocationTitleById`

## Testing
- `npm install` *(fails: network restricted)*
- `npm test` *(fails: cannot resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c95ead6088332a9d2524e932553c4