### PR TITLE
Limit zoom level for short segments

### DIFF
--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -150,7 +150,10 @@ const RouteMap = forwardRef(({
         [start[0], start[1]]
       );
       bounds.extend([end[0], end[1]]);
-      mapRef.current.fitBounds(bounds, { padding: 80, duration: 700 });
+      const dist = Math.hypot(end[0] - start[0], end[1] - start[1]) * 100000;
+      const options = { padding: 80, duration: 700 };
+      if (dist < 50) options.maxZoom = 17;
+      mapRef.current.fitBounds(bounds, options);
     }
   }, [currentStep, routeGeo]);
 

--- a/src/pages/RouteOverview.jsx
+++ b/src/pages/RouteOverview.jsx
@@ -114,15 +114,18 @@ const RouteOverview = () => {
         setDirectionArrow(computeTurn(b1, b2));
       }
 
+      const isShort = d < 50;
       setViewState({
         latitude: (lat1 + lat2) / 2,
         longitude: (lng1 + lng2) / 2,
-        zoom: 18
+        zoom: isShort ? 17 : 18
       });
       setPopupCoord([(lng1 + lng2) / 2, (lat1 + lat2) / 2]);
       if (mapRef.current) {
         const bounds = new maplibregl.LngLatBounds([lng1, lat1], [lng2, lat2]);
-        mapRef.current.fitBounds(bounds, { padding: 50, duration: 700 });
+        const options = { padding: 50, duration: 700 };
+        if (isShort) options.maxZoom = 17;
+        mapRef.current.fitBounds(bounds, options);
       }
     }
   }, [currentSlide, routeData]);


### PR DESCRIPTION
## Summary
- cap zoom at 17 when step distance is less than 50m in RouteOverview
- apply the same maxZoom option in RouteMap when switching steps

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687c96e94c1c8332a2064db1f4a5ebac