### PR TITLE
Localize digits for Persian-based languages

### DIFF
--- a/src/IntlProviderWrapper.jsx
+++ b/src/IntlProviderWrapper.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { IntlProvider } from 'react-intl';
+import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl';
 import { useLangStore } from './store/langStore';
 import fa from './locales/fa.json';
 import en from './locales/en.json';
@@ -9,6 +9,8 @@ import ur from './locales/ur.json';
 
 const messages = { fa, en, ar, ur };
 
+import { toPersianDigits } from './utils/digits';
+
 const IntlProviderWrapper = ({ children }) => {
   const language = useLangStore((state) => state.language);
   useEffect(() => {
@@ -16,10 +18,22 @@ const IntlProviderWrapper = ({ children }) => {
     document.documentElement.dir = language === 'en' ? 'ltr' : 'rtl';
   }, [language]);
 
+  const cache = createIntlCache();
+  const intl = createIntl({ locale: language, messages: messages[language], defaultLocale: 'fa' }, cache);
+
+  const originalFormatMessage = intl.formatMessage;
+  intl.formatMessage = (descriptor, values) => {
+    let msg = originalFormatMessage(descriptor, values);
+    if (['fa', 'ur', 'ar'].includes(language)) {
+      msg = toPersianDigits(msg);
+    }
+    return msg;
+  };
+
   return (
-    <IntlProvider locale={language} messages={messages[language]} defaultLocale="fa">
+    <RawIntlProvider value={intl}>
       {children}
-    </IntlProvider>
+    </RawIntlProvider>
   );
 };
 

--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -238,7 +238,9 @@ const Location = () => {
       const newComment = {
         author: intl.formatMessage({ id: 'defaultCommentAuthor' }),
         text: comment,
-        date: new Date().toLocaleDateString('fa-IR'),
+        date: ['fa', 'ur', 'ar'].includes(language)
+          ? new Date().toLocaleDateString('fa-IR')
+          : new Date().toLocaleDateString(),
         rating: rating || 0
       };
 

--- a/src/utils/digits.js
+++ b/src/utils/digits.js
@@ -1,0 +1,1 @@
+export const toPersianDigits = (str) => str.replace(/\d/g, d => '۰۱۲۳۴۵۶۷۸۹'[d]);


### PR DESCRIPTION
## Summary
- implement `toPersianDigits` utility
- patch `IntlProviderWrapper` to convert numbers when language is fa, ur, or ar
- format comment dates according to selected language

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687c972e05fc8332bad1918313255153