### PR TITLE
Fix QR start point name

### DIFF
--- a/src/components/map/MapComponent.jsx
+++ b/src/components/map/MapComponent.jsx
@@ -7,6 +7,7 @@ import osmStyle from '../../services/osmStyle';
 import { useLangStore } from '../../store/langStore';
 import { buildGeoJsonPath } from '../../utils/geojsonPath.js';
 import { groups } from '../groupData';
+import { getLocationTitleById } from '../../utils/getLocationTitle';
 
 const groupColors = {
   sahn: '#4caf50',
@@ -86,25 +87,33 @@ const MapComponent = ({
   useEffect(() => {
     const storedLat = sessionStorage.getItem('qrLat');
     const storedLng = sessionStorage.getItem('qrLng');
+    const storedId = sessionStorage.getItem('qrId');
     
     // Original shrine coordinates
     const shrineCoords = { lat: 36.2880, lng: 59.6157 };
     
     if (storedLat && storedLng) {
-      const coords = { 
-        lat: parseFloat(storedLat), 
-        lng: parseFloat(storedLng) 
+      const coords = {
+        lat: parseFloat(storedLat),
+        lng: parseFloat(storedLng)
       };
       setUserCoords(coords);
-      setUserLocation({
-        name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
-        coordinates: [coords.lat, coords.lng]
-      });
-      setViewState(v => ({ 
-        ...v, 
-        latitude: coords.lat, 
-        longitude: coords.lng, 
-        zoom: 18 
+      (async () => {
+        let name = intl.formatMessage({ id: 'mapCurrentLocationName' });
+        if (storedId) {
+          const title = await getLocationTitleById(storedId);
+          if (title) name = title;
+        }
+        setUserLocation({
+          name,
+          coordinates: [coords.lat, coords.lng]
+        });
+      })();
+      setViewState(v => ({
+        ...v,
+        latitude: coords.lat,
+        longitude: coords.lng,
+        zoom: 18
       }));
       return; // Skip GPS if QR code exists
     }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -20,9 +20,11 @@ if (search && search.includes('&amp;')) {
 const params = new URLSearchParams(search);
 const lat = params.get('lat');
 const lng = params.get('lng');
+const qrId = params.get('id');
 if (lat && lng) {
   sessionStorage.setItem('qrLat', lat);
   sessionStorage.setItem('qrLng', lng);
+  if (qrId) sessionStorage.setItem('qrId', qrId);
 
   // Also update the GPS store so components can use this location immediately
   const updateCurrentLocation = useGPSStore.getState().updateCurrentLocation;

--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -6,17 +6,20 @@ import { groups } from '../components/groupData';
 import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
+import { getLocationTitleById } from '../utils/getLocationTitle';
 import { useSearchStore } from '../store/searchStore';
 import '../styles/MapRouting.css';
 
 const MapRoutingPage = () => {
   const navigate = useNavigate();
   const intl = useIntl();
+  const language = useLangStore(state => state.language);
   const [showDestinationModal, setShowDestinationModal] = useState(false);
   const [showOriginModal, setShowOriginModal] = useState(false);
   const [selectedDestination, setSelectedDestination] = useState(null);
   const storedLat = sessionStorage.getItem('qrLat');
   const storedLng = sessionStorage.getItem('qrLng');
+  const storedId = sessionStorage.getItem('qrId');
   const initialUserLocation = storedLat && storedLng
     ? {
       name: intl.formatMessage({ id: 'mapCurrentLocationName' }),
@@ -35,9 +38,21 @@ const MapRoutingPage = () => {
   const [mapSelectedLocation, setMapSelectedLocation] = useState(null);
   const [selectedCategory, setSelectedCategory] = useState(null);
 
+  useEffect(() => {
+    if (storedLat && storedLng && storedId) {
+      getLocationTitleById(storedId).then((title) => {
+        if (title) {
+          setUserLocation({
+            name: title,
+            coordinates: [parseFloat(storedLat), parseFloat(storedLng)]
+          });
+        }
+      });
+    }
+  }, [storedLat, storedLng, storedId, language]);
+
   const setOriginStore = useRouteStore(state => state.setOrigin);
   const setDestinationStore = useRouteStore(state => state.setDestination);
-  const language = useLangStore(state => state.language);
   const recentSearches = useSearchStore(state => state.recentSearches);
   const addSearch = useSearchStore(state => state.addSearch);
 
@@ -259,10 +274,19 @@ const MapRoutingPage = () => {
   };
 
   const handleCurrentLocationSelect = () => {
-    setUserLocation((prev) => ({
-      ...prev,
-      name: intl.formatMessage({ id: 'mapCurrentLocationName' })
-    }));
+    if (storedLat && storedLng && storedId) {
+      getLocationTitleById(storedId).then((title) => {
+        setUserLocation({
+          name: title || intl.formatMessage({ id: 'mapCurrentLocationName' }),
+          coordinates: [parseFloat(storedLat), parseFloat(storedLng)]
+        });
+      });
+    } else {
+      setUserLocation((prev) => ({
+        ...prev,
+        name: intl.formatMessage({ id: 'mapCurrentLocationName' })
+      }));
+    }
     setShowOriginModal(false);
   };
 

--- a/src/pages/QRScan.jsx
+++ b/src/pages/QRScan.jsx
@@ -16,9 +16,11 @@ const QRScan = () => {
       const url = new URL(text);
       const lat = url.searchParams.get('lat');
       const lng = url.searchParams.get('lng');
+      const id = url.searchParams.get('id');
       if (lat && lng) {
         sessionStorage.setItem('qrLat', lat);
         sessionStorage.setItem('qrLng', lng);
+        if (id) sessionStorage.setItem('qrId', id);
         const loc = { lat: parseFloat(lat), lng: parseFloat(lng) };
         updateCurrentLocation({ coords: loc, timestamp: Date.now() });
         addQRCodeLocation(text, loc);

--- a/src/utils/getLocationTitle.js
+++ b/src/utils/getLocationTitle.js
@@ -1,0 +1,19 @@
+import { useLangStore } from '../store/langStore';
+
+export async function getLocationTitleById(id) {
+  try {
+    const lang = useLangStore.getState().language;
+    const res = await fetch('./data/locationData.json');
+    const data = await res.json();
+    const loc = Array.isArray(data) ? data.find(l => l.id === id) : data;
+    if (!loc) return null;
+    const { title } = loc;
+    if (title && typeof title === 'object' && !Array.isArray(title)) {
+      return title[lang] || title.fa || Object.values(title)[0];
+    }
+    return title || null;
+  } catch (err) {
+    console.error('failed to load location title', err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- persist QR id from URL when the app loads
- use stored QR id in MapRouting and MapComponent to load translated location titles

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687c95ead6088332a9d2524e932553c4