### PR TITLE
Ensure non-English digits render in Persian

### DIFF
--- a/src/components/map/DeadReckoningControls.jsx
+++ b/src/components/map/DeadReckoningControls.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
+import useLocaleDigits from '../../utils/useLocaleDigits';
 import advancedDeadReckoningService from '../../services/AdvancedDeadReckoningService';
 import '../../styles/DeadReckoning.css';
 
 const DeadReckoningControls = ({ currentLocation }) => {
   const intl = useIntl();
+  const formatDigits = useLocaleDigits();
   const [isActive, setIsActive] = useState(advancedDeadReckoningService.isActive);
   const [stepCount, setStepCount] = useState(0);
 
@@ -44,7 +46,7 @@ const DeadReckoningControls = ({ currentLocation }) => {
         {intl.formatMessage({ id: 'drReset' })}
       </button>
       <div className="step-counter">
-        {intl.formatMessage({ id: 'drStepCount' })} {stepCount}
+        {intl.formatMessage({ id: 'drStepCount' })} {formatDigits(stepCount)}
       </div>
     </div>
   );

--- a/src/components/map/Routing.jsx
+++ b/src/components/map/Routing.jsx
@@ -4,9 +4,11 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import osmStyle from '../../services/osmStyle';
 import GeoJsonOverlay from './GeoJsonOverlay';
+import useLocaleDigits from '../../utils/useLocaleDigits';
 
 
 const Routing = ({ userLocation, routeSteps, currentStep }) => {
+  const formatDigits = useLocaleDigits();
   const initial = routeSteps && routeSteps.length > 0 ? routeSteps[0].coordinates : [36.2880, 59.6157];
   const [viewState, setViewState] = useState({ latitude: initial[0], longitude: initial[1], zoom: 18 });
 
@@ -45,7 +47,7 @@ const Routing = ({ userLocation, routeSteps, currentStep }) => {
         {routeSteps &&
           routeSteps.map((step, idx) => (
             <Marker key={idx} longitude={step.coordinates[1]} latitude={step.coordinates[0]} anchor="bottom">
-              <div className={`custom-marker ${idx === currentStep ? 'active' : ''}`}>{idx + 1}</div>
+              <div className={`custom-marker ${idx === currentStep ? 'active' : ''}`}>{formatDigits(idx + 1)}</div>
             </Marker>
           ))}
         {routeSteps && (

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -13,6 +13,7 @@ import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
 import { analyzeRoute } from '../utils/routeAnalysis';
+import useLocaleDigits from '../utils/useLocaleDigits';
 import { toast } from 'react-toastify';
 
 const FinalSearch = () => {
@@ -21,6 +22,7 @@ const FinalSearch = () => {
   const mapRef = useRef(null);
   const navigate = useNavigate();
   const intl = useIntl();
+  const formatDigits = useLocaleDigits();
   const {
     origin: storedOrigin,
     destination: storedDestination,
@@ -760,7 +762,7 @@ const FinalSearch = () => {
           <div className="info-time">
             {getTransportIcon()}
             <span>
-              {routeInfo.time} <FormattedMessage id="minutesUnit" />
+              {formatDigits(routeInfo.time)} <FormattedMessage id="minutesUnit" />
             </span>
           </div>
           <div className="info-distance">
@@ -771,7 +773,7 @@ const FinalSearch = () => {
               <path d="M11 19h5.5a3.5 3.5 0 0 0 0 -7h-8a3.5 3.5 0 0 1 0 -7h4.5" />
             </svg>
             <span>
-              {routeInfo.distance} <FormattedMessage id="meters" />
+              {formatDigits(routeInfo.distance)} <FormattedMessage id="meters" />
             </span>
           </div>
         </div>

--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -8,6 +8,7 @@ import localizeLocationData from '../utils/localizeLocationData.js';
 import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { useSearchStore } from '../store/searchStore';
+import useLocaleDigits from '../utils/useLocaleDigits';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -36,6 +37,7 @@ const Location = () => {
 
   const locationId = getSearchParams().get('id');
   const intl = useIntl();
+  const formatDigits = useLocaleDigits();
   const [activeSlide, setActiveSlide] = useState(0);
   const [comment, setComment] = useState('');
   const [comments, setComments] = useState([]);
@@ -557,9 +559,9 @@ const Location = () => {
                 <path stroke="none" d="M0 0h24v24H0z" fill="none" />
                 <path d="M12 17.75l-6.172 3.245l1.179 -6.873l-5 -4.867l6.9 -1l3.086 -6.253l3.086 6.253l6.9 1l-5 4.867l1.179 6.873z" />
               </svg>
-              {overallRating.toFixed(1)}
+              {formatDigits(overallRating.toFixed(1))}
             </span>
-            <span className="views">({views} {intl.formatMessage({ id: 'commentsLabel' })})</span>
+            <span className="views">({formatDigits(views)} {intl.formatMessage({ id: 'commentsLabel' })})</span>
           </div>
         </div>
 
@@ -1008,7 +1010,7 @@ const Location = () => {
                                 </svg>
                               ))}
                             </div>
-                            <span className="place-views">({place.views} {intl.formatMessage({ id: 'commentsLabel' })})</span>
+                            <span className="place-views">({formatDigits(place.views)} {intl.formatMessage({ id: 'commentsLabel' })})</span>
                           </div>
                           <p className="place-description">{place.description}</p>
                           <button className="read-more-btn">

--- a/src/pages/RouteOverview.jsx
+++ b/src/pages/RouteOverview.jsx
@@ -8,10 +8,12 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import '../styles/RouteOverview.css';
 import osmStyle from '../services/osmStyle';
 import { useRouteStore } from '../store/routeStore';
+import useLocaleDigits from '../utils/useLocaleDigits';
 
 const RouteOverview = () => {
   const navigate = useNavigate();
   const intl = useIntl();
+  const formatDigits = useLocaleDigits();
 
   const mapRef = useRef(null);
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -99,10 +101,10 @@ const RouteOverview = () => {
       const [lng2, lat2] = segment[1];
       const d = Math.hypot(lng2 - lng1, lat2 - lat1) * 100000;
       setDistance(
-        `${Math.round(d)} ${intl.formatMessage({ id: 'meters' })}`
+        `${formatDigits(Math.round(d))} ${intl.formatMessage({ id: 'meters' })}`
       );
       setTime(
-        `${Math.max(1, Math.round(d / 60))} ${intl.formatMessage({ id: 'minutesUnit' })}`
+        `${formatDigits(Math.max(1, Math.round(d / 60)))} ${intl.formatMessage({ id: 'minutesUnit' })}`
       );
 
       if (currentSlide === routeData.length - 1) {

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -9,10 +9,12 @@ import { useRouteStore } from '../store/routeStore';
 import { useLangStore } from '../store/langStore';
 import { buildGeoJsonPath } from '../utils/geojsonPath.js';
 import { analyzeRoute } from '../utils/routeAnalysis';
+import useLocaleDigits from '../utils/useLocaleDigits';
 import { toast } from 'react-toastify';
 
 const RoutingPage = () => {
   const intl = useIntl();
+  const formatDigits = useLocaleDigits();
   const routeMapRef = useRef(null);
   const [isMapModalOpen, setIsMapModalOpen] = useState(true);
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(true);
@@ -972,7 +974,7 @@ const RoutingPage = () => {
                 <div className="all-routes-header">
                   <div className="all-routes-info">
                     <span><FormattedMessage id="arrivalTime" /></span>
-                    <span className="all-routes-arrival-time">{routeData.arrivalTime}</span>
+                    <span className="all-routes-arrival-time">{formatDigits(routeData.arrivalTime)}</span>
                   </div>
                   <div className="all-routes-details">
                     <div className="all-routes-item">
@@ -980,7 +982,7 @@ const RoutingPage = () => {
                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-walk"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M13 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" /><path d="M7 21l3 -4" /><path d="M16 21l-2 -4l-3 -3l1 -6" /><path d="M6 12l2 -3l4 -1l3 3l3 1" /></svg>
                       </div>
                       <div className="all-routes-text">
-                        <span className="all-routes-value">{routeData.totalTime}</span>
+                        <span className="all-routes-value">{formatDigits(routeData.totalTime)}</span>
                       </div>
                     </div>
                     <div className="all-routes-item">
@@ -988,7 +990,7 @@ const RoutingPage = () => {
                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-route"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 19a2 2 0 1 0 4 0a2 2 0 0 0 -4 0" /><path d="M19 7a2 2 0 1 0 0 -4a2 2 0 0 0 0 4z" /><path d="M11 19h5.5a3.5 3.5 0 0 0 0 -7h-8a3.5 3.5 0 0 1 0 -7h4.5" /></svg>
                       </div>
                       <div className="all-routes-text">
-                        <span className="all-routes-value">{routeData.totalDistance}</span>
+                        <span className="all-routes-value">{formatDigits(routeData.totalDistance)}</span>
                       </div>
                     </div>
                   </div>
@@ -1041,7 +1043,7 @@ const RoutingPage = () => {
                           <path d="M16 21l-2 -4l-3 -3l1 -6" />
                           <path d="M6 12l2 -3l4 -1l3 3l3 1" />
                         </svg>
-                        <span>{route.totalTime}</span>
+                        <span>{formatDigits(route.totalTime)}</span>
                       </div>
 
                       <div className="route-stat">
@@ -1051,7 +1053,7 @@ const RoutingPage = () => {
                           <path d="M19 7a2 2 0 1 0 0 -4a2 2 0 0 0 0 4z" />
                           <path d="M11 19h5.5a3.5 3.5 0 0 0 0 -7h-8a3.5 3.5 0 0 1 0 -7h4.5" />
                         </svg>
-                        <span>{route.totalDistance}</span>
+                        <span>{formatDigits(route.totalDistance)}</span>
                       </div>
                     </div>
 
@@ -1095,7 +1097,7 @@ const RoutingPage = () => {
                   <div className="info-title">
                     <div className="info-stat">
                       <span><FormattedMessage id="arrivalTime" /></span>
-                      <span className="arrival-time">{routeData.arrivalTime}</span>
+                      <span className="arrival-time">{formatDigits(routeData.arrivalTime)}</span>
                     </div>
                     <div className="info-details">
                       <div className="info-item">
@@ -1103,7 +1105,7 @@ const RoutingPage = () => {
                           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-walk"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M13 4m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" /><path d="M7 21l3 -4" /><path d="M16 21l-2 -4l-3 -3l1 -6" /><path d="M6 12l2 -3l4 -1l3 3l3 1" /></svg>
                         </div>
                         <div className="info-text">
-                          <span className="info-value">{routeData.totalTime}</span>
+                          <span className="info-value">{formatDigits(routeData.totalTime)}</span>
                         </div>
                       </div>
 
@@ -1112,7 +1114,7 @@ const RoutingPage = () => {
                           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="icon icon-tabler icons-tabler-outline icon-tabler-route"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M3 19a2 2 0 1 0 4 0a2 2 0 0 0 -4 0" /><path d="M19 7a2 2 0 1 0 0 -4a2 2 0 0 0 0 4z" /><path d="M11 19h5.5a3.5 3.5 0 0 0 0 -7h-8a3.5 3.5 0 0 1 0 -7h4.5" /></svg>
                         </div>
                         <div className="info-text">
-                          <span className="info-value">{routeData.totalDistance}</span>
+                          <span className="info-value">{formatDigits(routeData.totalDistance)}</span>
                         </div>
                       </div>
                     </div>

--- a/src/utils/digits.js
+++ b/src/utils/digits.js
@@ -1,1 +1,6 @@
 export const toPersianDigits = (str) => str.replace(/\d/g, d => '۰۱۲۳۴۵۶۷۸۹'[d]);
+
+export const toLocaleDigits = (value, language) => {
+  const str = String(value);
+  return language === 'en' ? str : toPersianDigits(str);
+};

--- a/src/utils/useLocaleDigits.js
+++ b/src/utils/useLocaleDigits.js
@@ -1,0 +1,9 @@
+import { useLangStore } from '../store/langStore';
+import { toLocaleDigits } from './digits';
+
+const useLocaleDigits = () => {
+  const language = useLangStore(state => state.language);
+  return (value) => toLocaleDigits(value, language);
+};
+
+export default useLocaleDigits;


### PR DESCRIPTION
## Summary
- add `toLocaleDigits` and `useLocaleDigits` utilities
- use the new number formatter across components

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687ca89a605483328d18319aa7737204