### PR TITLE
Fix door names using subgroup direction

### DIFF
--- a/public/data/data14040411.geojson
+++ b/public/data/data14040411.geojson
@@ -110,7 +110,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -2267,7 +2267,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "elmi",
         "subGroup": "سایر",
@@ -2335,7 +2335,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -2573,7 +2573,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی شرقی صحن انقلاب",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن انقلاب",
@@ -2607,7 +2607,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "ravaq",
         "subGroup": "سایر",
@@ -2675,7 +2675,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی غربی صحن انقلاب",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن انقلاب",
@@ -2709,7 +2709,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -2777,7 +2777,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی شمالی صحن غدیر",
         "description": "ورودی مهمانسرا",
         "group": "sahn",
         "subGroup": "صحن غدیر",
@@ -2811,7 +2811,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی غربی صحن غدیر",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن غدیر",
@@ -2845,7 +2845,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی غربی صحن غدیر",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن غدیر",
@@ -2879,7 +2879,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -3015,7 +3015,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "کتابخانه",
         "group": "ravaq",
         "subGroup": "سایر",
@@ -3049,7 +3049,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی غربی صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3083,7 +3083,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -3117,7 +3117,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "ravaq",
         "subGroup": "سایر",
@@ -3151,7 +3151,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "masjed",
         "subGroup": "سایر",
@@ -3185,7 +3185,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "masjed",
         "subGroup": "سایر",
@@ -3219,7 +3219,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "ravaq",
         "subGroup": "سایر",
@@ -3253,7 +3253,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -3287,7 +3287,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -3321,7 +3321,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی غربی صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3389,7 +3389,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی شرقی صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3423,7 +3423,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "ravaq",
         "subGroup": "سایر",
@@ -3491,7 +3491,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی شرقی صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3525,7 +3525,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -3593,7 +3593,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "ravaq",
         "subGroup": "سایر",
@@ -3627,7 +3627,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -3694,7 +3694,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -3728,7 +3728,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی شرقی صحن امام حسن مجتبی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن امام حسن مجتبی",
@@ -3796,7 +3796,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی شرقی صحن پیامبر اعظم",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن پیامبر اعظم",
@@ -3830,7 +3830,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -4136,7 +4136,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",
@@ -4340,7 +4340,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "masjed",
         "subGroup": "سایر",
@@ -4374,7 +4374,7 @@
         ]
       },
       "properties": {
-        "name": "ورودی",
+        "name": "ورودی سایر",
         "description": "",
         "group": "other",
         "subGroup": "سایر",

--- a/public/data/data14040411_ar.geojson
+++ b/public/data/data14040411_ar.geojson
@@ -110,7 +110,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -2267,7 +2267,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "elmi",
         "subGroup": "أخرى",
@@ -2335,7 +2335,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -2573,7 +2573,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الشرقي مدخل صحن الثورة",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الثورة",
@@ -2607,7 +2607,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "ravaq",
         "subGroup": "أخرى",
@@ -2675,7 +2675,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الغربي مدخل صحن الثورة",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الثورة",
@@ -2709,7 +2709,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -2777,7 +2777,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الشمالي مدخل صحن الغدير",
         "description": "ورودی مهمانسرا",
         "group": "sahn",
         "subGroup": "صحن الغدير",
@@ -2811,7 +2811,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الغربي مدخل صحن الغدير",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الغدير",
@@ -2845,7 +2845,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الغربي مدخل صحن الغدير",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الغدير",
@@ -2879,7 +2879,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -3015,7 +3015,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "کتابخانه",
         "group": "ravaq",
         "subGroup": "أخرى",
@@ -3049,7 +3049,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الغربي مدخل صحن الحرية",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الحرية",
@@ -3083,7 +3083,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -3117,7 +3117,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "ravaq",
         "subGroup": "أخرى",
@@ -3151,7 +3151,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "masjed",
         "subGroup": "أخرى",
@@ -3185,7 +3185,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "masjed",
         "subGroup": "أخرى",
@@ -3219,7 +3219,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "ravaq",
         "subGroup": "أخرى",
@@ -3253,7 +3253,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -3287,7 +3287,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -3321,7 +3321,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الغربي مدخل صحن الحرية",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الحرية",
@@ -3389,7 +3389,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الشرقي مدخل صحن الحرية",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الحرية",
@@ -3423,7 +3423,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "ravaq",
         "subGroup": "أخرى",
@@ -3491,7 +3491,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الشرقي مدخل صحن الحرية",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الحرية",
@@ -3525,7 +3525,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -3593,7 +3593,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "ravaq",
         "subGroup": "أخرى",
@@ -3627,7 +3627,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -3694,7 +3694,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -3728,7 +3728,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الشرقي مدخل صحن الإمام الحسن المجتبى",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن الإمام الحسن المجتبى",
@@ -3796,7 +3796,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "الشرقي مدخل صحن النبي الأعظم",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن النبي الأعظم",
@@ -3830,7 +3830,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -4136,7 +4136,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",
@@ -4340,7 +4340,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "masjed",
         "subGroup": "أخرى",
@@ -4374,7 +4374,7 @@
         ]
       },
       "properties": {
-        "name": "مدخل",
+        "name": "مدخل أخرى",
         "description": "",
         "group": "other",
         "subGroup": "أخرى",

--- a/public/data/data14040411_en.geojson
+++ b/public/data/data14040411_en.geojson
@@ -110,7 +110,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -2267,7 +2267,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "elmi",
         "subGroup": "Other",
@@ -2335,7 +2335,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -2573,7 +2573,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "East Entrance Enqelab Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Enqelab Courtyard",
@@ -2607,7 +2607,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "ravaq",
         "subGroup": "Other",
@@ -2675,7 +2675,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "West Entrance Enqelab Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Enqelab Courtyard",
@@ -2709,7 +2709,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -2777,7 +2777,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "North Entrance Ghadir Courtyard",
         "description": "ورودی مهمانسرا",
         "group": "sahn",
         "subGroup": "Ghadir Courtyard",
@@ -2811,7 +2811,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "West Entrance Ghadir Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Ghadir Courtyard",
@@ -2845,7 +2845,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "West Entrance Ghadir Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Ghadir Courtyard",
@@ -2879,7 +2879,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -3015,7 +3015,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "کتابخانه",
         "group": "ravaq",
         "subGroup": "Other",
@@ -3049,7 +3049,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "West Entrance Azadi Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Azadi Courtyard",
@@ -3083,7 +3083,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -3117,7 +3117,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "ravaq",
         "subGroup": "Other",
@@ -3151,7 +3151,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "masjed",
         "subGroup": "Other",
@@ -3185,7 +3185,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "masjed",
         "subGroup": "Other",
@@ -3219,7 +3219,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "ravaq",
         "subGroup": "Other",
@@ -3253,7 +3253,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -3287,7 +3287,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -3321,7 +3321,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "West Entrance Azadi Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Azadi Courtyard",
@@ -3389,7 +3389,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "East Entrance Azadi Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Azadi Courtyard",
@@ -3423,7 +3423,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "ravaq",
         "subGroup": "Other",
@@ -3491,7 +3491,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "East Entrance Azadi Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Azadi Courtyard",
@@ -3525,7 +3525,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -3593,7 +3593,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "ravaq",
         "subGroup": "Other",
@@ -3627,7 +3627,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -3694,7 +3694,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -3728,7 +3728,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "East Entrance Imam Hasan Mujtaba Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Imam Hasan Mujtaba Courtyard",
@@ -3796,7 +3796,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "East Entrance Prophet Mohammad Courtyard",
         "description": "",
         "group": "sahn",
         "subGroup": "Prophet Mohammad Courtyard",
@@ -3830,7 +3830,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -4136,7 +4136,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",
@@ -4340,7 +4340,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "masjed",
         "subGroup": "Other",
@@ -4374,7 +4374,7 @@
         ]
       },
       "properties": {
-        "name": "Entrance",
+        "name": "Entrance Other",
         "description": "",
         "group": "other",
         "subGroup": "Other",

--- a/public/data/data14040411_ur.geojson
+++ b/public/data/data14040411_ur.geojson
@@ -110,7 +110,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -2267,7 +2267,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "elmi",
         "subGroup": "دیگر",
@@ -2335,7 +2335,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -2573,7 +2573,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مشرقی داخلہ صحن انقلاب",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن انقلاب",
@@ -2607,7 +2607,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "ravaq",
         "subGroup": "دیگر",
@@ -2675,7 +2675,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مغربی داخلہ صحن انقلاب",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن انقلاب",
@@ -2709,7 +2709,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -2777,7 +2777,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "شمالی داخلہ صحن غدیر",
         "description": "ورودی مهمانسرا",
         "group": "sahn",
         "subGroup": "صحن غدیر",
@@ -2811,7 +2811,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مغربی داخلہ صحن غدیر",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن غدیر",
@@ -2845,7 +2845,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مغربی داخلہ صحن غدیر",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن غدیر",
@@ -2879,7 +2879,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -3015,7 +3015,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "کتابخانه",
         "group": "ravaq",
         "subGroup": "دیگر",
@@ -3049,7 +3049,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مغربی داخلہ صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3083,7 +3083,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -3117,7 +3117,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "ravaq",
         "subGroup": "دیگر",
@@ -3151,7 +3151,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "masjed",
         "subGroup": "دیگر",
@@ -3185,7 +3185,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "masjed",
         "subGroup": "دیگر",
@@ -3219,7 +3219,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "ravaq",
         "subGroup": "دیگر",
@@ -3253,7 +3253,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -3287,7 +3287,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -3321,7 +3321,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مغربی داخلہ صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3389,7 +3389,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مشرقی داخلہ صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3423,7 +3423,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "ravaq",
         "subGroup": "دیگر",
@@ -3491,7 +3491,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مشرقی داخلہ صحن آزادی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن آزادی",
@@ -3525,7 +3525,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -3593,7 +3593,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "ravaq",
         "subGroup": "دیگر",
@@ -3627,7 +3627,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -3694,7 +3694,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -3728,7 +3728,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مشرقی داخلہ صحن امام حسن مجتبی",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن امام حسن مجتبی",
@@ -3796,7 +3796,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "مشرقی داخلہ صحن پیغمبر اعظم",
         "description": "",
         "group": "sahn",
         "subGroup": "صحن پیغمبر اعظم",
@@ -3830,7 +3830,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -4136,7 +4136,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",
@@ -4340,7 +4340,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "masjed",
         "subGroup": "دیگر",
@@ -4374,7 +4374,7 @@
         ]
       },
       "properties": {
-        "name": "داخلہ",
+        "name": "داخلہ دیگر",
         "description": "",
         "group": "other",
         "subGroup": "دیگر",


### PR DESCRIPTION
## Summary
- clarify door orientation like "East Entrance Enqelab Courtyard" across datasets

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687cafc70c808332a9716263bb832a6c