### PR TITLE
Fix routing summary fallback

### DIFF
--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -369,7 +369,7 @@ const RoutingPage = () => {
 
   // Load route data from JSON for initial display when no analyzed route exists
   useEffect(() => {
-    if (routeSteps.length) return;
+    if (routeSteps.length || routeGeo) return;
     fetch('./data/routeData.json')
       .then(response => response.json())
       .then(data => {
@@ -385,7 +385,7 @@ const RoutingPage = () => {
         });
       })
       .catch(error => console.error('Error loading route data:', error));
-  }, [routeSteps.length]);
+  }, [routeSteps.length, routeGeo]);
 
   // Build route data from stored steps
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure default route data is only loaded when neither route steps nor route geometry exist

## Testing
- `npm install` *(fails: network restricted)*
- `npm test` *(fails: cannot find module because dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687d16d1ab7c833291addfb1570b2bd3