### PR TITLE
Persist final search route info for routing page

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -91,22 +91,32 @@ const FinalSearch = () => {
   }, []);
 
   React.useEffect(() => {
+    let info;
     if (routeGeo) {
       const coords = routeGeo.geometry?.coordinates || [];
       const dist = coords.slice(1).reduce((acc, c, i) => {
         const prev = coords[i];
         return acc + Math.hypot(c[0] - prev[0], c[1] - prev[1]) * 100000;
       }, 0);
-      setRouteInfo({
+      info = {
         time: `${Math.max(1, Math.round(dist / 60))}`,
         distance: `${Math.round(dist)}`
-      });
+      };
     } else if (transportMode === 'walking') {
-      setRouteInfo({ time: '9', distance: '75' });
+      info = { time: '9', distance: '75' };
     } else if (transportMode === 'electric-car') {
-      setRouteInfo({ time: '5', distance: '120' });
+      info = { time: '5', distance: '120' };
     } else if (transportMode === 'wheelchair') {
-      setRouteInfo({ time: '12', distance: '65' });
+      info = { time: '12', distance: '65' };
+    }
+
+    if (info) {
+      setRouteInfo(info);
+      try {
+        sessionStorage.setItem('routeSummaryData', JSON.stringify(info));
+      } catch (err) {
+        console.warn('failed to persist route summary', err);
+      }
     }
   }, [transportMode, routeGeo]);
 


### PR DESCRIPTION
## Summary
- persist calculated route summary in FinalSearch page
- when no route steps exist in Routing page, pull summary from session storage for consistent time and distance

## Testing
- `npm test` *(fails: Cannot find package 'zustand' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_687d1b69869083329540d8a877b99a93