### PR TITLE
Persist final search route info for routing page

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -91,22 +91,32 @@ const FinalSearch = () => {
   }, []);
 
   React.useEffect(() => {
+    let info;
     if (routeGeo) {
       const coords = routeGeo.geometry?.coordinates || [];
       const dist = coords.slice(1).reduce((acc, c, i) => {
         const prev = coords[i];
         return acc + Math.hypot(c[0] - prev[0], c[1] - prev[1]) * 100000;
       }, 0);
-      setRouteInfo({
+      info = {
         time: `${Math.max(1, Math.round(dist / 60))}`,
         distance: `${Math.round(dist)}`
-      });
+      };
     } else if (transportMode === 'walking') {
-      setRouteInfo({ time: '9', distance: '75' });
+      info = { time: '9', distance: '75' };
     } else if (transportMode === 'electric-car') {
-      setRouteInfo({ time: '5', distance: '120' });
+      info = { time: '5', distance: '120' };
     } else if (transportMode === 'wheelchair') {
-      setRouteInfo({ time: '12', distance: '65' });
+      info = { time: '12', distance: '65' };
+    }
+
+    if (info) {
+      setRouteInfo(info);
+      try {
+        sessionStorage.setItem('routeSummaryData', JSON.stringify(info));
+      } catch (err) {
+        console.warn('failed to persist route summary', err);
+      }
     }
   }, [transportMode, routeGeo]);
 

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -223,19 +223,33 @@ const RoutingPage = () => {
   };
 
   // If no steps available but route geometry exists (e.g. when navigating
-  // directly from the search page), compute summary info from the geometry so
-  // the displayed time and distance match the final search page.
+  // directly from the search page), compute summary info from stored summary
+  // or from the geometry so the displayed values match the final search page.
   useEffect(() => {
     if (!routeGeo || routeSteps.length) return;
 
-    const coords = routeGeo.geometry.coordinates || [];
-    if (coords.length === 0) return;
+    let minutes;
+    let dist;
+    try {
+      const stored = sessionStorage.getItem('routeSummaryData');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        minutes = parseInt(parsed.time, 10);
+        dist = parseInt(parsed.distance, 10);
+      }
+    } catch (err) {
+      console.warn('failed to read stored route summary', err);
+    }
 
-    const dist = coords.slice(1).reduce((acc, c, i) => {
-      const prev = coords[i];
-      return acc + Math.hypot(c[0] - prev[0], c[1] - prev[1]) * 100000;
-    }, 0);
-    const minutes = Math.max(1, Math.round(dist / 60));
+    if (!minutes || !dist) {
+      const coords = routeGeo.geometry.coordinates || [];
+      if (coords.length === 0) return;
+      dist = coords.slice(1).reduce((acc, c, i) => {
+        const prev = coords[i];
+        return acc + Math.hypot(c[0] - prev[0], c[1] - prev[1]) * 100000;
+      }, 0);
+      minutes = Math.max(1, Math.round(dist / 60));
+    }
 
     setRouteData(prev => ({
       steps: [],
@@ -423,10 +437,26 @@ const RoutingPage = () => {
         direction
       };
     });
-    const totalMinutes = calculateTotalTime(steps);
+    // Use summary from session storage if available to ensure consistency with
+    // the FinalSearch page calculations
+    let summaryMinutes;
+    let summaryDistance;
+    try {
+      const stored = sessionStorage.getItem('routeSummaryData');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        summaryMinutes = parseInt(parsed.time, 10);
+        summaryDistance = parseInt(parsed.distance, 10);
+      }
+    } catch (err) {
+      console.warn('failed to read stored route summary', err);
+    }
+
+    const totalMinutes = summaryMinutes || calculateTotalTime(steps);
+    const totalDistance = summaryDistance ||
+      steps.reduce((acc, st) => acc + parseInt(st.distance), 0);
     const formattedTotalTime = formatTotalTime(totalMinutes);
     const arrivalTime = calculateArrivalTime(totalMinutes);
-    const totalDistance = steps.reduce((acc, st) => acc + parseInt(st.distance), 0);
 
     const alternativesData = (alternativeRoutes || []).map((alt, ridx) => {
       const altCoords = alt.geo.geometry.coordinates;
@@ -483,6 +513,18 @@ const RoutingPage = () => {
       totalDistance: `${totalDistance} ${intl.formatMessage({ id: 'meters' })}`,
       alternativeRoutes: alternativesData
     });
+
+    try {
+      sessionStorage.setItem(
+        'routeSummaryData',
+        JSON.stringify({
+          time: totalMinutes.toString(),
+          distance: totalDistance.toString()
+        })
+      );
+    } catch (err) {
+      console.warn('failed to persist route summary', err);
+    }
   }, [routeSteps, routeGeo, alternativeRoutes]);
 
   // Update arrival time every minute


### PR DESCRIPTION
## Summary
- persist calculated route summary in FinalSearch page
- when no route steps exist in Routing page, pull summary from session storage for consistent time and distance
- use stored route summary even when steps are present

## Testing
- `npm test` *(fails: Cannot find package 'zustand' due to offline environment)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687d1b69869083329540d8a877b99a93