### PR TITLE
Fix missing intl translations on language page

### DIFF
--- a/src/pages/LangPage.jsx
+++ b/src/pages/LangPage.jsx
@@ -13,10 +13,10 @@ const LangPage = () => {
   const intl = useIntl();
 
   const languages = [
-    { id: 1, name: 'فارسی', code: '(FA)', locale: 'fa', englishName: intl.formatMessage({ id: 'Persian' }) },
-    { id: 2, name: 'اردو', code: '(Ur)', locale: 'ur', englishName: intl.formatMessage({ id: 'Urdu' }) },
-    { id: 3, name: 'العربیة', code: '(AR)', locale: 'ar', englishName: intl.formatMessage({ id: 'Arabic' }) },
-    { id: 4, name: 'English', code: '(EN)', locale: 'en', englishName: intl.formatMessage({ id: 'English' }) }
+    { id: 1, name: 'فارسی', code: '(FA)', locale: 'fa', englishName: 'Persian' },
+    { id: 2, name: 'اردو', code: '(Ur)', locale: 'ur', englishName: 'Urdu' },
+    { id: 3, name: 'العربیة', code: '(AR)', locale: 'ar', englishName: 'Arabic' },
+    { id: 4, name: 'English', code: '(EN)', locale: 'en', englishName: 'English' }
   ];
 
   const handleLogin = () => {


### PR DESCRIPTION
## Summary
- avoid calling `intl.formatMessage` for language names that don't exist in some locales

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687f94c6d9108332a9fc387486d76957