### PR TITLE
Fix swap bug

### DIFF
--- a/src/pages/MapRouting.jsx
+++ b/src/pages/MapRouting.jsx
@@ -234,15 +234,23 @@ const MapRoutingPage = () => {
   }, [searchQuery, geoData]);
 
   const handleSwapLocations = () => {
+    // Do nothing if either location is missing
+    if (!selectedDestination || !userLocation) {
+      return;
+    }
+
     const temp = userLocation;
-    setUserLocation(
-      selectedDestination
-        ? { name: selectedDestination.name, coordinates: selectedDestination.coordinates }
-        : null
-    );
-    setSelectedDestination(
-      temp ? { name: temp.name, location: temp.name, coordinates: temp.coordinates } : null
-    );
+
+    setUserLocation({
+      name: selectedDestination.name,
+      coordinates: selectedDestination.coordinates
+    });
+
+    setSelectedDestination({
+      name: temp.name,
+      location: temp.name,
+      coordinates: temp.coordinates
+    });
 
     if (swapButtonRef.current) {
       swapButtonRef.current.classList.add('rotate');


### PR DESCRIPTION
## Summary
- avoid assigning null when swapping origin and destination

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_687f98a3e9048332974799e578decb43