### PR TITLE
Localize route popup minutes

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -608,7 +608,7 @@ const FinalSearch = () => {
                     anchor="bottom"
                   >
                     <div className="time-popup alt-popup">
-                      {altPopupMinutes[idx]} {intl.formatMessage({ id: 'minutesUnit' })}
+                      {formatDigits(altPopupMinutes[idx])} {intl.formatMessage({ id: 'minutesUnit' })}
                     </div>
                   </Popup>
                 )}
@@ -629,7 +629,7 @@ const FinalSearch = () => {
               anchor="bottom"
             >
               <div className="time-popup main-popup">
-                {popupMinutes} {intl.formatMessage({ id: 'minutesUnit' })}
+                {formatDigits(popupMinutes)} {intl.formatMessage({ id: 'minutesUnit' })}
               </div>
             </Popup>
           )}


### PR DESCRIPTION
## Summary
- localize minute values shown in Final Search map pop-ups

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_6888982a914c833297b1e80f0facdf89