### PR TITLE
Fix subgroup translation in Location page

### DIFF
--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -1250,7 +1250,7 @@ const Location = () => {
                   {/* Split subgroups into those with images and without */}
                   <div className="subgroups-with-images">
                     <div className="subgroups-grid">
-                      {subGroups[selectedCategory.value]
+                      {(filteredSubGroups.length > 0 ? filteredSubGroups : subGroups[selectedCategory.value])
                         .filter(subgroup => subgroup.img)
                         .map((subgroup, index) => (
                           <div
@@ -1275,7 +1275,7 @@ const Location = () => {
                   </div>
 
                   <div className="subgroups-without-images">
-                    {subGroups[selectedCategory.value]
+                    {(filteredSubGroups.length > 0 ? filteredSubGroups : subGroups[selectedCategory.value])
                       .filter(subgroup => !subgroup.img)
                       .map((subgroup, index) => (
                         <div


### PR DESCRIPTION
## Summary
- ensure subgroup names come from localized data when viewing subgroups in the location search modal

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_68889d0c07148332a47b3b093afde15e