### PR TITLE
Fix subgroup translation in Location page

### DIFF
--- a/src/components/groupData.js
+++ b/src/components/groupData.js
@@ -134,7 +134,7 @@ export const subGroups = {
       label: 'صحن انقلاب',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s1
     },
     {
@@ -142,7 +142,7 @@ export const subGroups = {
       label: 'صحن آزادی',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s2
     },
     {
@@ -150,7 +150,7 @@ export const subGroups = {
       label: 'صحن جمهوری اسلامی',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s3
     },
     {
@@ -158,7 +158,7 @@ export const subGroups = {
       label: 'صحن قدس',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s4
     },
     {
@@ -166,7 +166,7 @@ export const subGroups = {
       label: 'صحن جامع رضوی',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s5
     },
     {
@@ -174,7 +174,7 @@ export const subGroups = {
       label: 'صحن غدیر',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s6
     },
     {
@@ -182,7 +182,7 @@ export const subGroups = {
       label: 'صحن کوثر',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s7
     },
     {
@@ -190,7 +190,7 @@ export const subGroups = {
       label: 'صحن امام حسن مجتبی',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s8
     },
     {
@@ -198,7 +198,7 @@ export const subGroups = {
       label: 'صحن پیامبر اعظم',
       icon: 'courtyard',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M14 12v.01"/><path d="M3 21h18"/><path d="M6 21v-16a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v16"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s9
     }
   ],
@@ -208,7 +208,7 @@ export const subGroups = {
       label: 'ایوان عباسی',
       icon: 'eyvan',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21l18 0"/><path d="M4 21v-15a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v15"/><path d="M9 21v-8a3 3 0 0 1 6 0v8"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s10
     },
     {
@@ -216,7 +216,7 @@ export const subGroups = {
       label: 'ایوان طلایی',
       icon: 'eyvan',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21l18 0"/><path d="M4 21v-15a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v15"/><path d="M9 21v-8a3 3 0 0 1 6 0v8"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s11
     },
     {
@@ -224,7 +224,7 @@ export const subGroups = {
       label: 'ایوان ساعت',
       icon: 'eyvan',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21l18 0"/><path d="M4 21v-15a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v15"/><path d="M9 21v-8a3 3 0 0 1 6 0v8"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s12
     },
     {
@@ -232,7 +232,7 @@ export const subGroups = {
       label: 'ایوان نقاره',
       icon: 'eyvan',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21l18 0"/><path d="M4 21v-15a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v15"/><path d="M9 21v-8a3 3 0 0 1 6 0v8"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s13
     },
     {
@@ -240,7 +240,7 @@ export const subGroups = {
       label: 'ایوان ولیعصر',
       icon: 'eyvan',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21l18 0"/><path d="M4 21v-15a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v15"/><path d="M9 21v-8a3 3 0 0 1 6 0v8"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s14
     },
     {
@@ -248,7 +248,7 @@ export const subGroups = {
       label: 'ایوان طلای آزادی',
       icon: 'eyvan',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21l18 0"/><path d="M4 21v-15a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v15"/><path d="M9 21v-8a3 3 0 0 1 6 0v8"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s15
     }
   ],
@@ -258,7 +258,7 @@ export const subGroups = {
       label: 'دارالحفاظ',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s16
     },
     {
@@ -266,7 +266,7 @@ export const subGroups = {
       label: 'دارالسياده',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s17
     },
     {
@@ -274,7 +274,7 @@ export const subGroups = {
       label: 'دارالسلام',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s18
     },
     {
@@ -282,7 +282,7 @@ export const subGroups = {
       label: 'حاتم خانی',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s19
     },
     {
@@ -290,7 +290,7 @@ export const subGroups = {
       label: 'گنبدالله وردی خان',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s20
     },
     {
@@ -298,7 +298,7 @@ export const subGroups = {
       label: 'دارالضیافه',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s21
     },
     {
@@ -306,7 +306,7 @@ export const subGroups = {
       label: 'توحیدخانه',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s22
     },
     {
@@ -314,14 +314,14 @@ export const subGroups = {
       label: 'دارالفیض',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s23
     },
     {
       value: 'daralsaade',
       label: 'دارالسعاده', icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s24
     },
     {
@@ -329,7 +329,7 @@ export const subGroups = {
       label: 'گوهرشاد',
       icon: 'shrine',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 18l2 -13l2 -2l2 2l2 13"/><path d="M5 21v-3h14v3"/><path d="M3 21l18 0"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s25
     }
   ],
@@ -339,7 +339,7 @@ export const subGroups = {
       label: 'بالاسر',
       icon: 'mosque',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h7v-2a2 2 0 1 1 4 0v2h7"/><path d="M4 21v-10"/><path d="M20 21v-10"/><path d="M4 16h3v-3h10v3h3"/><path d="M17 13a5 5 0 0 0 -10 0"/><path d="M21 10.5c0 -.329 -.077 -.653 -.224 -.947l-.776 -1.553l-.776 1.553a2.118 2.118 0 0 0 -.224 .947a.5 .5 0 0 0 .5 .5h1a.5 .5 0 0 0 .5 -.5z"/><path d="M5 10.5c0 -.329 -.077 -.653 -.224 -.947l-.776 -1.553l-.776 1.553a2.118 2.118 0 0 0 -.224 .947a.5 .5 0 0 0 .5 .5h1a.5 .5 0 0 0 .5 -.5z"/><path d="M12 2a2 2 0 1 0 2 2"/><path d="M12 6v2"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s26
     },
     {
@@ -347,7 +347,7 @@ export const subGroups = {
       label: 'گوهرشاد',
       icon: 'mosque',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h7v-2a2 2 0 1 1 4 0v2h7"/><path d="M4 21v-10"/><path d="M20 21v-10"/><path d="M4 16h3v-3h10v3h3"/><path d="M17 13a5 5 0 0 0 -10 0"/><path d="M21 10.5c0 -.329 -.077 -.653 -.224 -.947l-.776 -1.553l-.776 1.553a2.118 2.118 0 0 0 -.224 .947a.5 .5 0 0 0 .5 .5h1a.5 .5 0 0 0 .5 -.5z"/><path d="M5 10.5c0 -.329 -.077 -.653 -.224 -.947l-.776 -1.553l-.776 1.553a2.118 2.118 0 0 0 -.224 .947a.5 .5 0 0 0 .5 .5h1a.5 .5 0 0 0 .5 -.5z"/><path d="M12 2a2 2 0 1 0 2 2"/><path d="M12 6v2"/></svg>`,
-      description: 'توضیحات',
+      description: "subgroupDefaultDesc",
       img: s27
     }
   ],
@@ -357,28 +357,28 @@ export const subGroups = {
       label: 'پایین خیابان',
       icon: 'school',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'bala-khyaban',
       label: 'بالا خیابان',
       icon: 'school',
       svg: `<svg xmlns="http://www.w3.org/24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'navvab',
       label: 'نواب',
       icon: 'school',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'dodar',
       label: 'دودر',
       icon: 'school',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M22 9l-10 -4l-10 4l10 4l10 -4v6"/><path d="M6 10.6v5.4a6 3 0 0 0 12 0v-5.4"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     }
   ],
   khadamat: [
@@ -387,42 +387,42 @@ export const subGroups = {
       label: 'دستشویی',
       icon: 'services',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h4l13 -13a1.5 1.5 0 0 0 -4 -4l-13 13v4"/><path d="M14.5 5.5l4 4"/><path d="M12 8l-5 -5l-4 4l5 5"/><path d="M7 8l-1.5 1.5"/><path d="M16 12l5 5l-4 4l-5 -5"/><path d="M16 17l-1.5 1.5"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'telephon',
       label: 'تلفن',
       icon: 'services',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h4l13 -13a1.5 1.5 0 0 0 -4 -4l-13 13v4"/><path d="M14.5 5.5l4 4"/><path d="M12 8l-5 -5l-4 4l5 5"/><path d="M7 8l-1.5 1.5"/><path d="M16 12l5 5l-4 4l-5 -5"/><path d="M16 17l-1.5 1.5"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'otag-madadjo',
       label: 'اتاق مددجو',
       icon: 'services',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h4l13 -13a1.5 1.5 0 0 0 -4 -4l-13 13v4"/><path d="M14.5 5.5l4 4"/><path d="M12 8l-5 -5l-4 4l5 5"/><path d="M7 8l-1.5 1.5"/><path d="M16 12l5 5l-4 4l-5 -5"/><path d="M16 17l-1.5 1.5"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'namaazkhane',
       label: 'نمازخانه',
       icon: 'services',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h4l13 -13a1.5 1.5 0 0 0 -4 -4l-13 13v4"/><path d="M14.5 5.5l4 4"/><path d="M12 8l-5 -5l-4 4l5 5"/><path d="M7 8l-1.5 1.5"/><path d="M16 12l5 5l-4 4l-5 -5"/><path d="M16 17l-1.5 1.5"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'ketabkhane',
       label: 'کتابخانه',
       icon: 'services',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h4l13 -13a1.5 1.5 0 0 0 -4 -4l-13 13v4"/><path d="M14.5 5.5l4 4"/><path d="M12 8l-5 -5l-4 4l5 5"/><path d="M7 8l-1.5 1.5"/><path d="M16 12l5 5l-4 4l-5 -5"/><path d="M16 17l-1.5 1.5"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'room',
       label: 'اتاق',
       icon: 'services',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 21h4l13 -13a1.5 1.5 0 0 0 -4 -4l-13 13v4"/><path d="M14.5 5.5l4 4"/><path d="M12 8l-5 -5l-4 4l5 5"/><path d="M7 8l-1.5 1.5"/><path d="M16 12l5 5l-4 4l-5 -5"/><path d="M16 17l-1.5 1.5"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     }
   ],
   elmi: [
@@ -431,21 +431,21 @@ export const subGroups = {
       label: 'حوزه علمیه',
       icon: 'culture',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 19a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6l0 13"/><path d="M12 6l0 13"/><path d="M21 6l0 13"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'markaz-motaleat',
       label: 'مرکز مطالعات',
       icon: 'culture',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 19a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6l0 13"/><path d="M12 6l0 13"/><path d="M21 6l0 13"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'uni',
       label: 'دانشگاه',
       icon: 'culture',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M3 19a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6l0 13"/><path d="M12 6l0 13"/><path d="M21 6l0 13"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     }
   ],
   cemetery: [
@@ -454,14 +454,14 @@ export const subGroups = {
       label: 'قبر',
       icon: 'cemetery',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 4v16"/><path d="M19 4v16"/><path d="M9 4v16"/><path d="M15 4v16"/><path d="M3 4h18"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'yadbod',
       label: 'یادبود',
       icon: 'cemetery',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M5 4v16"/><path d="M19 4v16"/><path d="M9 4v16"/><path d="M15 4v16"/><path d="M3 4h18"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     }
   ],
   qrcode: [
@@ -470,14 +470,14 @@ export const subGroups = {
       label: 'بخش کنترل',
       icon: 'qr-code',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"/><path d="M7 17l0 .01"/><path d="M14 4m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"/><path d="M7 7l0 .01"/><path d="M4 14m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"/><path d="M17 7l0 .01"/><path d="M14 14l3 0"/><path d="M20 14l0 .01"/><path d="M14 14l0 3"/><path d="M14 20l3 0"/><path d="M17 17l3 0"/><path d="M20 17l0 3"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     },
     {
       value: 'cctv',
       label: 'دوربین مدار بسته',
       icon: 'qr-code',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M4 4m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"/><path d="M7 17l0 .01"/><path d="M14 4m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"/><path d="M7 7l0 .01"/><path d="M4 14m0 1a1 1 0 0 1 1 -1h4a1 1 0 0 1 1 1v4a1 1 0 0 1 -1 1h-4a1 1 0 0 1 -1 -1z"/><path d="M17 7l0 .01"/><path d="M14 14l3 0"/><path d="M20 14l0 .01"/><path d="M14 14l0 3"/><path d="M14 20l3 0"/><path d="M17 17l3 0"/><path d="M20 17l0 3"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     }
   ],
   elevator: [],
@@ -487,7 +487,7 @@ export const subGroups = {
       label: 'سایر',
       icon: 'other',
       svg: `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M8 9l3 3l-3 3"/><path d="M13 15l3 0"/><path d="M3 4m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v12a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"/></svg>`,
-      description: 'توضیحات'
+      description: "subgroupDefaultDesc"
     }
   ]
 };

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -63,6 +63,7 @@
   "defaultCommentAuthor": "مستخدم جديد",
   "searchSuggestions": "اقتراحات البحث",
   "loading": "جار التحميل...",
+  "subgroupDefaultDesc": "الوصف",
   "fetchError": "خطأ في جلب البيانات: {error}",
   "noDataFound": "لم يتم العثور على بيانات",
   "goToSlide": "الانتقال إلى الشريحة {n}",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,7 @@
   "defaultCommentAuthor": "New user",
   "searchSuggestions": "Search suggestions",
   "loading": "Loading...",
+  "subgroupDefaultDesc": "Description",
   "fetchError": "Error fetching data: {error}",
   "noDataFound": "No data found",
   "goToSlide": "Go to slide {n}",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -63,6 +63,7 @@
   "defaultCommentAuthor": "کاربر جدید",
   "searchSuggestions": "پیشنهاد‌های جستجو",
   "loading": "در حال بارگذاری...",
+  "subgroupDefaultDesc": "توضیحات",
   "fetchError": "خطا در دریافت اطلاعات: {error}",
   "noDataFound": "موردی یافت نشد",
   "goToSlide": "رفتن به اسلاید {n}",

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -63,6 +63,7 @@
   "defaultCommentAuthor": "نیا صارف",
   "searchSuggestions": "تلاش کی تجاویز",
   "loading": "لوڈ ہو رہا ہے...",
+  "subgroupDefaultDesc": "تفصیل",
   "fetchError": "ڈیٹا حاصل کرنے میں خرابی: {error}",
   "noDataFound": "کوئی ڈیٹا نہیں ملا",
   "goToSlide": "سلائیڈ {n} پر جائیں",

--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -30,6 +30,17 @@ const getLocalizedSubgroupLabel = (geoData, value, fallback) => {
   return fallback;
 };
 
+// Get subgroup description based on currently loaded geoData
+const getLocalizedSubgroupDescription = (geoData, value, fallback) => {
+  if (geoData) {
+    const feature = geoData.features.find(
+      f => f.properties?.subGroupValue === value
+    );
+    if (feature?.properties?.description) return feature.properties.description;
+  }
+  return fallback;
+};
+
 const Location = () => {
   const navigate = useNavigate();
   const currentLocation = useReactLocation();
@@ -413,7 +424,11 @@ const Location = () => {
             results.push({
               type: 'subgroup',
               label,
-              description: f.properties?.description || '',
+              description: getLocalizedSubgroupDescription(
+                geoData,
+                f.properties?.subGroupValue,
+                intl.formatMessage({ id: 'subgroupDefaultDesc' })
+              ),
               groupValue: f.properties?.group,
               subGroupValue: f.properties?.subGroupValue
             });
@@ -432,7 +447,12 @@ const Location = () => {
     setSelectedCategory(category);
     const localized = (subGroups[category.value] || []).map(sg => ({
       ...sg,
-      label: getLocalizedSubgroupLabel(geoData, sg.value, sg.label)
+      label: getLocalizedSubgroupLabel(geoData, sg.value, sg.label),
+      description: getLocalizedSubgroupDescription(
+        geoData,
+        sg.value,
+        intl.formatMessage({ id: sg.description })
+      )
     }));
     setFilteredSubGroups(localized);
     setShowSearchModal(true);
@@ -1250,7 +1270,7 @@ const Location = () => {
                   {/* Split subgroups into those with images and without */}
                   <div className="subgroups-with-images">
                     <div className="subgroups-grid">
-                      {subGroups[selectedCategory.value]
+                      {(filteredSubGroups.length > 0 ? filteredSubGroups : subGroups[selectedCategory.value])
                         .filter(subgroup => subgroup.img)
                         .map((subgroup, index) => (
                           <div
@@ -1275,7 +1295,7 @@ const Location = () => {
                   </div>
 
                   <div className="subgroups-without-images">
-                    {subGroups[selectedCategory.value]
+                    {(filteredSubGroups.length > 0 ? filteredSubGroups : subGroups[selectedCategory.value])
                       .filter(subgroup => !subgroup.img)
                       .map((subgroup, index) => (
                         <div


### PR DESCRIPTION
## Summary
- localize subgroup descriptions using language files or geo data
- add translation keys for the default subgroup description

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*

------
https://chatgpt.com/codex/tasks/task_e_68889d0c07148332a47b3b093afde15e