### PR TITLE
Fix leftover popups when route not found

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -276,6 +276,14 @@ const FinalSearch = () => {
     }
   }, [routeGeo]);
 
+  // Clear popup information when no route is available
+  useEffect(() => {
+    if (!routeGeo || !(routeGeo.geometry?.coordinates?.length > 0)) {
+      setPopupCoord(null);
+      setPopupMinutes(null);
+    }
+  }, [routeGeo]);
+
   // Determine popup location and total minutes for main route
   useEffect(() => {
     if (!routeGeo) return;
@@ -311,7 +319,7 @@ const FinalSearch = () => {
 
   // Determine popup locations and minutes for alternative routes
   useEffect(() => {
-    if (!storedAlternativeRoutes) {
+    if (!storedAlternativeRoutes || storedAlternativeRoutes.length === 0 || !routeGeo) {
       setAltPopupCoords([]);
       setAltPopupMinutes([]);
       return;

--- a/src/pages/RouteOverview.jsx
+++ b/src/pages/RouteOverview.jsx
@@ -132,6 +132,13 @@ const RouteOverview = () => {
     }
   }, [currentSlide, routeData]);
 
+  // Clear popup when no route data is available
+  useEffect(() => {
+    if (!routeCoordinates || routeCoordinates.length === 0) {
+      setPopupCoord(null);
+    }
+  }, [routeCoordinates]);
+
   const allGeo = {
     type: 'Feature',
     geometry: { type: 'LineString', coordinates: routeCoordinates }


### PR DESCRIPTION
## Summary
- reset map popups when routeGeo is cleared or has no coordinates
- clear alternative route popups when no alternatives exist
- clear popup on overview page when no route data is available

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*
- `npm run lint` *(fails: cannot connect to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6888d65ff8e88332ab4c6b2ce2a3310c