### PR TITLE
Fix session route reuse in RNG

### DIFF
--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -368,9 +368,36 @@ const FinalSearch = () => {
   const swapLocations = () => {
     setIsSwapping(true); // This will trigger the rotation
     setSwapButton(!isSwapButton);
-    const temp = origin;
-    setOrigin(destination);
-    setDestination(temp);
+    const newOrigin = destination;
+    const newDestination = origin;
+    setOrigin(newOrigin);
+    setDestination(newDestination);
+    storeSetOrigin(newOrigin);
+    storeSetDestination(newDestination);
+    sessionStorage.setItem('origin', JSON.stringify(newOrigin));
+    sessionStorage.setItem('destination', JSON.stringify(newDestination));
+    sessionStorage.setItem('qrLat', String(newOrigin.coordinates[0]));
+    sessionStorage.setItem('qrLng', String(newOrigin.coordinates[1]));
+    // Immediately rebuild the route so session data stays in sync
+    if (geoData) {
+      const result = analyzeRoute(
+        newOrigin,
+        newDestination,
+        geoData,
+        transportMode,
+        selectedGender
+      );
+      if (result) {
+        const { geo, steps, alternatives, sahns } = result;
+        storeSetRouteGeo(geo);
+        storeSetRouteSteps(steps);
+        storeSetAlternativeRoutes(alternatives);
+        sessionStorage.setItem('routeGeo', JSON.stringify(geo));
+        sessionStorage.setItem('routeSteps', JSON.stringify(steps));
+        sessionStorage.setItem('alternativeRoutes', JSON.stringify(alternatives));
+        sessionStorage.setItem('routeSahns', JSON.stringify(sahns));
+      }
+    }
   };
 
   const handleSelectAlternativeRoute = (route) => {

--- a/src/pages/Routing.jsx
+++ b/src/pages/Routing.jsx
@@ -117,8 +117,10 @@ const RoutingPage = () => {
     const lng = parseFloat(storedLng);
     const sessGeo = sessionStorage.getItem('routeGeo');
     const sessSteps = sessionStorage.getItem('routeSteps');
-    if (sessGeo && sessSteps && !routeSteps.length) {
-      // wait for session data to load via the first effect
+    if (sessGeo && sessSteps) {
+      // A route already exists in session storage. Use that data
+      // instead of rebuilding with the QR coordinates to avoid
+      // overwriting routes generated after swapping origin and destination.
       return;
     }
 
@@ -126,13 +128,6 @@ const RoutingPage = () => {
       !origin ||
       origin.coordinates?.[0] !== lat ||
       origin.coordinates?.[1] !== lng;
-
-
-    if (sessGeo && sessSteps && !originChanged) {
-      // Session data already provides the route; the first effect will
-      // load it into state so skip rebuilding here
-      return;
-    }
 
     if (!routeSteps.length || originChanged) {
       const newOrigin = {


### PR DESCRIPTION
## Summary
- ensure swapped origin persists to QR session keys so RNG shows the correct route

## Testing
- `npm test` *(fails: Cannot find package 'zustand')*


------
https://chatgpt.com/codex/tasks/task_e_68891757fb60833299bf8db4247d64ac