### PR TITLE
Add TTS guidance playback for routing

### DIFF
--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -129,6 +129,8 @@
   "soundOptionOn": "تشغيل",
   "soundOptionAlertOnly": "تنبيهات فقط",
   "soundOptionOff": "إيقاف",
+  "nextStepAnnouncement": "الخطوة التالية: {instruction}",
+  "ttsPlaybackError": "تعذّر تشغيل الإرشاد الصوتي. يُرجى متابعة التعليمات الظاهرة على الشاشة.",
   "emergencyButtonLabel": "طوارئ الحرم",
   "arrivalTime": "وقت الوصول",
   "routeOverview": "خطوات المسار",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -130,6 +130,8 @@
   "soundOptionOn": "On",
   "soundOptionAlertOnly": "Alerts only",
   "soundOptionOff": "Off",
+  "nextStepAnnouncement": "Next: {instruction}",
+  "ttsPlaybackError": "Couldn't play navigation audio. Please continue following the on-screen instructions.",
   "emergencyButtonLabel": "Shrine emergencies",
   "arrivalTime": "Arrival time",
   "routeOverview": "Route Steps",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -129,6 +129,8 @@
   "soundOptionOn": "روشن",
   "soundOptionAlertOnly": "فقط هشدار",
   "soundOptionOff": "خاموش",
+  "nextStepAnnouncement": "گام بعدی: {instruction}",
+  "ttsPlaybackError": "پخش راهنمای صوتی انجام نشد. لطفاً مسیر را با راهنمای روی صفحه ادامه دهید.",
   "emergencyButtonLabel": "فوریت‌های حرم",
   "arrivalTime": "زمان رسیدن",
   "routeOverview": " گام های مسیر  ",

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -129,6 +129,8 @@
   "soundOptionOn": "آن",
   "soundOptionAlertOnly": "صرف انتباہ",
   "soundOptionOff": "بند",
+  "nextStepAnnouncement": "اگلا مرحلہ: {instruction}",
+  "ttsPlaybackError": "نیویگیشن کی آواز چل نہیں سکی۔ براہ کرم اسکرین پر موجود ہدایات پر عمل جاری رکھیں۔",
   "emergencyButtonLabel": "حرم ہنگامی حالات",
   "arrivalTime": "پہنچنے کا وقت",
   "routeOverview": "راستے کے مراحل",

--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -1,0 +1,98 @@
+const AUTH_URL = 'https://api.aipaa.ir/auth/token/';
+const TTS_URL = 'https://api.aipaa.ir/api/v1/voice/tts-file-response/';
+
+let cachedToken = null;
+let tokenExpiry = 0;
+
+const username = import.meta.env.VITE_TTS_USERNAME;
+const password = import.meta.env.VITE_TTS_PASSWORD;
+const clientId = import.meta.env.VITE_TTS_CLIENT_ID;
+
+const ensureCredentials = () => {
+  if (!username || !password || !clientId) {
+    throw new Error('Missing TTS credentials');
+  }
+};
+
+const requestToken = async () => {
+  ensureCredentials();
+
+  const response = await fetch(AUTH_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      username,
+      password,
+      client_id: clientId
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Authentication failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  const token = data.access || data.access_token || data.token;
+  const expiresIn = data.expires_in || data.expire_in || 300;
+
+  if (!token) {
+    throw new Error('Authentication response missing access token');
+  }
+
+  cachedToken = token;
+  tokenExpiry = Date.now() + (expiresIn - 5) * 1000;
+  return cachedToken;
+};
+
+const getToken = async () => {
+  if (cachedToken && Date.now() < tokenExpiry) {
+    return cachedToken;
+  }
+  cachedToken = null;
+  return requestToken();
+};
+
+const fetchSpeech = async (text, payload = {}) => {
+  if (!text || !text.trim()) {
+    throw new Error('No text provided for TTS');
+  }
+
+  const body = {
+    text,
+    ...payload
+  };
+
+  let token = await getToken();
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await fetch(TTS_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(body)
+    });
+
+    if (response.status === 401 && attempt === 0) {
+      cachedToken = null;
+      tokenExpiry = 0;
+      token = await getToken();
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`TTS request failed with status ${response.status}`);
+    }
+
+    return response.blob();
+  }
+
+  throw new Error('Unauthorized TTS request');
+};
+
+export default {
+  fetchSpeech
+};


### PR DESCRIPTION
## Summary
- add a reusable TTS service that authenticates with the AIPAA API, caches tokens, and returns binary audio for instructions
- stream navigation steps through the TTS service when routing is active, including alert-only handling and localized next-step announcements
- translate the new announcements and error messaging across English, Persian, Arabic, and Urdu locale files

## Testing
- npm run lint *(fails: required packages cannot be installed because registry access to @eslint/js is forbidden in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9714028cc8332a23b6ee8dc80d9bd