### PR TITLE
Include grant_type when requesting TTS token

### DIFF
--- a/src/services/ttsService.js
+++ b/src/services/ttsService.js
@@ -25,7 +25,8 @@ const requestToken = async () => {
     body: JSON.stringify({
       username,
       password,
-      client_id: clientId
+      client_id: clientId,
+      grant_type: 'password'
     })
   });
 


### PR DESCRIPTION
## Summary
- include the `grant_type` field in the authentication payload for TTS token requests to ensure the expected grant type is sent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97b389f908332bb09954c1424c57c