### PR TITLE
Adjust about narration continuation logic

### DIFF
--- a/src/pages/Location.jsx
+++ b/src/pages/Location.jsx
@@ -198,10 +198,25 @@ const Location = () => {
       return;
     }
 
-    const textToSpeak = (showFullAbout ? locationData.about.full : locationData.about.short)
-      || locationData.about.full
-      || locationData.about.short
-      || '';
+    const shortAbout = locationData.about?.short ?? '';
+    const fullAbout = locationData.about?.full ?? '';
+
+    const trimmedShortAbout = shortAbout.trim();
+    const trimmedFullAbout = fullAbout.trim();
+
+    let textToSpeak;
+
+    if (showFullAbout) {
+      let continuation = '';
+
+      if (trimmedFullAbout && trimmedShortAbout && trimmedFullAbout.startsWith(trimmedShortAbout)) {
+        continuation = trimmedFullAbout.slice(trimmedShortAbout.length).trim();
+      }
+
+      textToSpeak = continuation || trimmedFullAbout || trimmedShortAbout || '';
+    } else {
+      textToSpeak = trimmedShortAbout || trimmedFullAbout || '';
+    }
 
     if (!textToSpeak?.trim()) {
       return;


### PR DESCRIPTION
## Summary
- trim and capture both short and full about copy for speech synthesis
- when expanding about copy, speak only the continuation beyond the short text while keeping audio cleanup behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9933ab84c83329a9a3d6f4ad3a335