### PR TITLE
Overlay OSM overlay tiles on Esri imagery

### DIFF
--- a/src/components/map/Mpbc.jsx
+++ b/src/components/map/Mpbc.jsx
@@ -3,7 +3,7 @@ import Map, { Marker, Source, Layer } from 'react-map-gl';
 import { useIntl } from 'react-intl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import osmStyle from '../../services/osmStyle';
+import esriImageryStyle from '../../services/esriImageryStyle';
 import { useLangStore } from '../../store/langStore';
 import { buildGeoJsonPath } from '../../utils/geojsonPath.js';
 import { groups, subGroups } from '../groupData';
@@ -382,7 +382,7 @@ const Mpbc = ({
   return (
     <Map
       mapLib={maplibregl}
-      mapStyle={osmStyle}
+      mapStyle={esriImageryStyle}
       style={{ width: '100%', height: '100%' }}
       {...viewState}
       onMove={onMove}

--- a/src/components/map/Mprc.jsx
+++ b/src/components/map/Mprc.jsx
@@ -3,7 +3,7 @@ import Map, { Marker, Source, Layer } from 'react-map-gl';
 import { useIntl } from 'react-intl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import osmStyle from '../../services/osmStyle';
+import esriImageryStyle from '../../services/esriImageryStyle';
 import { useLangStore } from '../../store/langStore';
 import { buildGeoJsonPath } from '../../utils/geojsonPath.js';
 import { groups } from '../groupData';
@@ -312,7 +312,7 @@ const Mprc = ({
   return (
     <Map
       mapLib={maplibregl}
-      mapStyle={osmStyle}
+      mapStyle={esriImageryStyle}
       style={{ width: '100%', height: '100%' }}
       {...viewState}
       onMove={onMove}

--- a/src/components/map/RouteMap.jsx
+++ b/src/components/map/RouteMap.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import osmStyle from '../../services/osmStyle';
+import esriImageryStyle from '../../services/esriImageryStyle';
 import GeoJsonOverlay from './GeoJsonOverlay';
 import advancedDeadReckoningService from '../../services/AdvancedDeadReckoningService';
 import ArrowMarker from './ArrowMarker';
@@ -237,7 +237,7 @@ const RouteMap = forwardRef(({
     <Map
       ref={mapRef}
       mapLib={maplibregl}
-      mapStyle={osmStyle}
+      mapStyle={esriImageryStyle}
       interactiveLayerIds={altLayerIds}
       onClick={(e) => {
         const feature = e.features && e.features[0];

--- a/src/components/map/Routing.jsx
+++ b/src/components/map/Routing.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Map, { Marker, Source, Layer } from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import osmStyle from '../../services/osmStyle';
+import esriImageryStyle from '../../services/esriImageryStyle';
 import GeoJsonOverlay from './GeoJsonOverlay';
 import useLocaleDigits from '../../utils/useLocaleDigits';
 
@@ -35,7 +35,7 @@ const Routing = ({ userLocation, routeSteps, currentStep }) => {
     <div ref={null} className="route-map">
       <Map
         mapLib={maplibregl}
-        mapStyle={osmStyle}
+        mapStyle={esriImageryStyle}
         style={{ width: '100%', height: '100%' }}
         viewState={viewState}
       >

--- a/src/pages/FinalSearch.jsx
+++ b/src/pages/FinalSearch.jsx
@@ -6,7 +6,7 @@ import Map, { Marker, Source, Layer, Popup } from 'react-map-gl';
 import GeoJsonOverlay from '../components/map/GeoJsonOverlay';
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
-import osmStyle from '../services/osmStyle';
+import esriImageryStyle from '../services/esriImageryStyle';
 import '../styles/FinalSearch.css';
 import ModeSelector from '../components/common/ModeSelector';
 import { useRouteStore } from '../store/routeStore';
@@ -559,7 +559,7 @@ const FinalSearch = () => {
         <Map
           ref={mapRef}
           mapLib={maplibregl}
-          mapStyle={osmStyle}
+          mapStyle={esriImageryStyle}
           style={{ width: '100%', height: '100%' }}
           initialViewState={{
             longitude:

--- a/src/pages/RouteOverview.jsx
+++ b/src/pages/RouteOverview.jsx
@@ -7,7 +7,7 @@ import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { groups, subGroups } from '../components/groupData';
 import '../styles/RouteOverview.css';
-import osmStyle from '../services/osmStyle';
+import esriImageryStyle from '../services/esriImageryStyle';
 import { useRouteStore } from '../store/routeStore';
 import useLocaleDigits from '../utils/useLocaleDigits';
 
@@ -355,7 +355,7 @@ const RouteOverview = () => {
         <Map
           ref={mapRef}
           mapLib={maplibregl}
-          mapStyle={osmStyle}
+          mapStyle={esriImageryStyle}
           initialViewState={viewState}
           attributionControl={false}
           style={{ width: '100%', height: '100%' }}

--- a/src/services/esriImageryStyle.js
+++ b/src/services/esriImageryStyle.js
@@ -1,0 +1,44 @@
+const esriImageryStyle = {
+  version: 8,
+  sources: {
+    'esri-imagery': {
+      type: 'raster',
+      tiles: [
+        'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
+      ],
+      tileSize: 256,
+      attribution:
+        'Tiles © Esri — Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community'
+    },
+    'osm-overlay': {
+      type: 'raster',
+      tiles: [
+        'https://ows.terrestris.de/osm/service?SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image/png&TRANSPARENT=TRUE&LAYERS=OSM-WMS&SRS=EPSG:3857&BBOX={bbox-epsg-3857}&WIDTH=256&HEIGHT=256'
+      ],
+      tileSize: 256,
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }
+  },
+  layers: [
+    {
+      id: 'esri-imagery',
+      type: 'raster',
+      source: 'esri-imagery',
+      minzoom: 0,
+      maxzoom: 19
+    },
+    {
+      id: 'osm-overlay',
+      type: 'raster',
+      source: 'osm-overlay',
+      minzoom: 0,
+      maxzoom: 19,
+      paint: {
+        'raster-opacity': 1
+      }
+    }
+  ]
+};
+
+export default esriImageryStyle;


### PR DESCRIPTION
## Summary
- add an Esri World Imagery raster style definition for MapLibre
- update all map components and pages to use the new Esri imagery style
- overlay a transparent OSM WMS layer on the Esri imagery style to render roads and labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd86d8bf3883328708d7aae1c20232