### PR TITLE
Add terrain DEM source to support 3D map view

### DIFF
--- a/src/services/esriImageryStyle.js
+++ b/src/services/esriImageryStyle.js
@@ -18,6 +18,13 @@ const esriImageryStyle = {
       tileSize: 256,
       attribution:
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    },
+    terrain: {
+      type: 'raster-dem',
+      tiles: ['https://demotiles.maplibre.org/terrain-tiles/tiles/{z}/{x}/{y}.png'],
+      tileSize: 256,
+      maxzoom: 14,
+      encoding: 'terrarium'
     }
   },
   layers: [


### PR DESCRIPTION
## Summary
- add the MapLibre terrain raster-dem source to the imagery style so 3D mode can request terrain tiles without errors

## Testing
- npm test *(fails: Cannot find package '/workspace/golden_path/node_modules/zustand/index.js' imported from /workspace/golden_path/src/store/langStore.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9f2511808332b42eb50a062b9bdb