### PR TITLE
Align QR code coordinates across localized geojson files

### DIFF
--- a/public/data/data14040411_ar.geojson
+++ b/public/data/data14040411_ar.geojson
@@ -3994,10 +3994,10 @@
       "type": "Feature",
       "geometry": {
         "type": "Point",
-        "coordinates": [
-          59.613146781921394,
-          36.28519150988027
-        ]
+      "coordinates": [
+        59.6132264183836,
+        36.285146386878694
+      ]
       },
       "properties": {
         "name": "Qr Code",
@@ -4016,8 +4016,8 @@
         "gender": "family",
         "nodeFunction": "qrcode",
         "restrictedTimes": [],
-        "latitude": 36.28519150988027,
-        "longitude": 59.613146781921394,
+        "latitude": 36.285146386878694,
+        "longitude": 59.6132264183836,
         "gpsMeta": {},
         "timestamp": "2025-07-02T08:55:45.898Z",
         "uniqueId": "sahn-payambar-azam_2658",

--- a/public/data/data14040411_en.geojson
+++ b/public/data/data14040411_en.geojson
@@ -3994,10 +3994,10 @@
       "type": "Feature",
       "geometry": {
         "type": "Point",
-        "coordinates": [
-          59.613146781921394,
-          36.28519150988027
-        ]
+      "coordinates": [
+        59.6132264183836,
+        36.285146386878694
+      ]
       },
       "properties": {
         "name": "Qr Code",
@@ -4016,8 +4016,8 @@
         "gender": "family",
         "nodeFunction": "qrcode",
         "restrictedTimes": [],
-        "latitude": 36.28519150988027,
-        "longitude": 59.613146781921394,
+        "latitude": 36.285146386878694,
+        "longitude": 59.6132264183836,
         "gpsMeta": {},
         "timestamp": "2025-07-02T08:55:45.898Z",
         "uniqueId": "sahn-payambar-azam_2658",

--- a/public/data/data14040411_ur.geojson
+++ b/public/data/data14040411_ur.geojson
@@ -3994,10 +3994,10 @@
       "type": "Feature",
       "geometry": {
         "type": "Point",
-        "coordinates": [
-          59.613146781921394,
-          36.28519150988027
-        ]
+      "coordinates": [
+        59.6132264183836,
+        36.285146386878694
+      ]
       },
       "properties": {
         "name": "Qr Code",
@@ -4016,8 +4016,8 @@
         "gender": "family",
         "nodeFunction": "qrcode",
         "restrictedTimes": [],
-        "latitude": 36.28519150988027,
-        "longitude": 59.613146781921394,
+        "latitude": 36.285146386878694,
+        "longitude": 59.6132264183836,
         "gpsMeta": {},
         "timestamp": "2025-07-02T08:55:45.898Z",
         "uniqueId": "sahn-payambar-azam_2658",


### PR DESCRIPTION
## Summary
- align the geometry and coordinate fields for the `sahn-payambar-azam_2658` QR code feature in the English, Arabic, and Urdu geojson datasets with the updated Persian source

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de081b00ec8332b43ebbb5d47c7a2f