### PR TITLE
Support predefined geojson routes

### DIFF
--- a/tests/routeAnalysis.test.js
+++ b/tests/routeAnalysis.test.js
@@ -88,3 +88,31 @@ const totalDistance = complexRoute.path.reduce((acc, cur, idx) => {
 assert.ok(totalDistance < 0.00075, 'A* should find optimal diagonal path');
 
 console.log('complex route test passed');
+
+// Predefined drawn route should be selected when start/end match
+const geoPredefined = {
+  type: 'FeatureCollection',
+  features: [
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: { nodeFunction: 'door', name: 'Start Door', services: { walking: true }, gender: 'family' } },
+    { type: 'Feature', geometry: { type: 'Point', coordinates: [0.0002, 0.0002] }, properties: { nodeFunction: 'door', name: 'End Door', services: { walking: true }, gender: 'family' } },
+    { type: 'Feature', geometry: { type: 'LineString', coordinates: [[0, 0], [0.0001, 0.0001], [0.0002, 0.0002]] }, properties: { services: { walking: true }, gender: 'family' } }
+  ]
+};
+
+const origin4 = { coordinates: [0, 0], name: 'Start Door' };
+const destination4 = { coordinates: [0.0002, 0.0002], name: 'End Door' };
+const predefinedRoute = analyzeRoute(origin4, destination4, geoPredefined, 'walking', 'family');
+
+assert.deepStrictEqual(
+  predefinedRoute.geo.geometry.coordinates,
+  [[0, 0], [0.0001, 0.0001], [0.0002, 0.0002]]
+);
+
+assert.strictEqual(
+  predefinedRoute.steps[predefinedRoute.steps.length - 1].type,
+  'stepArriveDestination'
+);
+
+assert.strictEqual(predefinedRoute.alternatives.length, 0);
+
+console.log('predefined geojson route test passed');


### PR DESCRIPTION
## Summary
- add haversine and geojson helpers to detect drawn routes whose endpoints align with the requested origin and destination
- snap matched LineString paths to nearby nodes to build route steps and reuse the predefined geometry
- cover the new behaviour with a unit test that ensures analyzeRoute prefers the predefined path

## Testing
- npm test --silent *(fails: cannot find package 'zustand')*


------
https://chatgpt.com/codex/tasks/task_e_68de071f6a848332a0ba8b4a20c58ccd