### PR TITLE
Handle mixed-case family routing access

### DIFF
--- a/src/utils/routeAnalysis.js
+++ b/src/utils/routeAnalysis.js
@@ -801,10 +801,28 @@ export function analyzeRoute(origin, destination, geoData, transportMode = 'walk
     return true;
   };
 
+  const normalizeGender = value => {
+    if (!value && value !== 0) return [];
+    if (Array.isArray(value)) return value;
+    if (typeof value === 'string') {
+      if (!value.trim()) return [];
+      return value.split(',');
+    }
+    return [value];
+  };
+
   const genderAllowed = (nodeGender, selected) => {
-    if (!nodeGender || nodeGender === 'family') return true;
-    if (selected === 'family') return true;
-    return nodeGender === selected;
+    const normalizedSelected = typeof selected === 'string' ? selected.toLowerCase() : '';
+    const genders = normalizeGender(nodeGender)
+      .map(g => (typeof g === 'string' ? g.toLowerCase().trim() : ''))
+      .filter(Boolean);
+
+    if (!genders.length) return true;
+    if (genders.includes('family')) return true;
+    if (normalizedSelected === 'family') {
+      return genders.some(g => g === 'male' || g === 'female');
+    }
+    return genders.includes(normalizedSelected);
   };
 
   if (!geoData) {

--- a/tests/routeAnalysis.test.js
+++ b/tests/routeAnalysis.test.js
@@ -69,6 +69,35 @@ assert.strictEqual(
   'female routes should not include male-only connection'
 );
 
+const geoFamilyCase = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0] },
+      properties: { nodeFunction: 'door', name: 'Family Start', services: { walking: true }, gender: 'Family' }
+    },
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0.0001] },
+      properties: { nodeFunction: 'connection', name: 'Family Connection', services: { walking: true }, gender: 'Family' }
+    },
+    {
+      type: 'Feature',
+      geometry: { type: 'Point', coordinates: [0, 0.0002] },
+      properties: { nodeFunction: 'door', name: 'Family End', services: { walking: true }, gender: 'Family' }
+    }
+  ]
+};
+
+const maleFamilyRoute = analyzeRoute(origin2, destination2, geoFamilyCase, 'walking', 'male');
+
+assert.ok(maleFamilyRoute, 'male route should exist through mixed-case family path');
+assert.ok(
+  maleFamilyRoute.steps.some(step => step.type === 'stepPassConnection'),
+  'male routes should traverse connections marked as Family'
+);
+
 console.log('analyzeRoute service filtering tests passed');
 
 // Complex routing test using multiple intermediate nodes


### PR DESCRIPTION
## Summary
- normalize gender metadata handling in the routing analyzer to accept comma-delimited or mixed-case values and keep family paths available to men and women
- add a regression test covering traversal of connections marked with the Family gender label

## Testing
- npm test *(fails: missing `zustand` package because it cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de50714b3083329395324150dee1a1