### PR TITLE
Handle Vite base URL when building GeoJSON paths

### DIFF
--- a/src/utils/geojsonPath.js
+++ b/src/utils/geojsonPath.js
@@ -1,5 +1,16 @@
 export function buildGeoJsonPath(language = 'fa') {
-  const base = import.meta?.env?.BASE_URL ?? '/';
+  let baseFromVite;
+  try {
+    baseFromVite = import.meta.env.BASE_URL;
+  } catch (error) {
+    baseFromVite = undefined;
+  }
+
+  const runtimeOverride =
+    typeof globalThis !== 'undefined' ? globalThis.__GEOJSON_BASE_URL__ : undefined;
+
+  const base = baseFromVite ?? runtimeOverride ?? '/';
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
   const suffix = language && language !== 'fa' ? `_${language}` : '';
-  return `${base}data/data14040411${suffix}.geojson`;
+  return `${normalizedBase}data/data14040411${suffix}.geojson`;
 }

--- a/tests/geojsonPath.test.js
+++ b/tests/geojsonPath.test.js
@@ -1,19 +1,31 @@
 import assert from 'assert';
 import { buildGeoJsonPath } from '../src/utils/geojsonPath.js';
 
+delete globalThis.__GEOJSON_BASE_URL__;
 assert.strictEqual(
   buildGeoJsonPath('fa'),
   '/data/data14040411.geojson',
-  'should build default fa path'
+  'should build default fa path when BASE_URL is absent'
 );
 assert.strictEqual(
   buildGeoJsonPath('en'),
   '/data/data14040411_en.geojson',
-  'should build english path'
+  'should build english path when BASE_URL is absent'
 );
+
+globalThis.__GEOJSON_BASE_URL__ = '/custom-base/';
+assert.strictEqual(
+  buildGeoJsonPath('fa'),
+  '/custom-base/data/data14040411.geojson',
+  'should prepend custom BASE_URL that already includes trailing slash'
+);
+
+globalThis.__GEOJSON_BASE_URL__ = '/custom-base';
 assert.strictEqual(
   buildGeoJsonPath('ar'),
-  '/data/data14040411_ar.geojson',
-  'should build arabic path'
+  '/custom-base/data/data14040411_ar.geojson',
+  'should normalize custom BASE_URL without trailing slash'
 );
+
+delete globalThis.__GEOJSON_BASE_URL__;
 console.log('geojsonPath tests passed');


### PR DESCRIPTION
## Summary
- read the Vite-provided `import.meta.env.BASE_URL` when composing GeoJSON paths and normalize trailing slashes
- add a runtime override for non-Vite environments so Node tests can validate BASE_URL-aware behavior
- expand the geojsonPath tests to cover default, trailing slash, and normalization scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de9a22094483329570eb2f900c88ed